### PR TITLE
Unwrap the exceptions of type InvocationTargetException

### DIFF
--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/processor/StoryProcessor.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/processor/StoryProcessor.java
@@ -21,6 +21,7 @@ import static java.util.Arrays.asList;
 import gherkin.deps.com.google.gson.Gson;
 import gherkin.deps.com.google.gson.reflect.TypeToken;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -100,6 +101,9 @@ public class StoryProcessor {
                 final MethodDetails details = calls.get(i);
                 details.getMethod().invoke(instance, details.getArguments());
             }
+        } catch (final InvocationTargetException ex) {
+            processReports(reports, ex.getCause());
+            throw ex.getCause();
         } catch (final Throwable t) {
             processReports(reports, t);
             throw t;

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/story/processor/StoryProcessorAnnotationTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/story/processor/StoryProcessorAnnotationTest.java
@@ -12,7 +12,10 @@ import gherkin.deps.com.google.gson.Gson;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ComparisonFailure;
 import org.junit.Test;
 
 import com.github.bmsantos.core.cola.formatter.ReportDetails;
@@ -35,6 +38,14 @@ public class StoryProcessorAnnotationTest {
         "Given Beta\n"
             + "When 101 is inserted\n"
             + "Then the true real method will execute";
+
+    private final String exceptionStory =
+            "Given a first method\n"
+                + "And a second method\n"
+                + "When the first method is called\n"
+                + "And the second method is called\n"
+                + "Then the first method will execute\n"
+                + "But the second method assertion will throw an exception";
 
     private final String noReport = "";
 
@@ -145,6 +156,20 @@ public class StoryProcessorAnnotationTest {
         verify(report).report(reportDetails.getArguments(), null);
     }
 
+    @Test
+    public void shouldUnwrapTheException() throws Throwable {
+        // When
+    	try {
+	        StoryProcessor.process("Feature: I'm a feature", "Scenario: Should Process Story", exceptionStory, projectionValues,
+	            noReport, instance);
+	        Assert.fail("exception should be thrown");
+    	} catch(Throwable t) {
+            // Then 
+    		assertThat(t, IsInstanceOf.instanceOf(ComparisonFailure.class));
+    	}
+        
+    }
+
     private class TestClass {
 
         public boolean wasGivenCalled = false;
@@ -204,6 +229,11 @@ public class StoryProcessorAnnotationTest {
         @Then("the (unreal|true real) method will execute")
         public void thenTheRealMethodWillExecute() {
             executionOrder.add(Thread.currentThread().getStackTrace()[1].getMethodName());
+        }
+        
+        @Then("the second method assertion will throw an exception")
+        public void thenThrowAnException() throws Exception {
+        	throw new ComparisonFailure("message", "0", "1");
         }
     }
 


### PR DESCRIPTION
Hi,

I started using your libray and quite like it so far. However I personally like to use AssertJ in my tests instead of hamcrest and if there is an error in my test the output is always:

```
java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at ...
```

This makes it hard to understand the real error and this is caused by the fact you use reflection to invoke the test steps. So I believe it is the duty of the StoryProcessor to unwrap the exception to get something more meaningful like:

```
org.junit.ComparisonFailure: expected:<1[2]> but was:<1[5]>
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at com.github.bmsantos.maven.cola.ExamplesColaTest.then(ExamplesColaTest.java:43)
	at ...
```

I hope my explanation is clear. Please let me know if the pull request is acceptable.

Thanks
