### PR TITLE
Adding support for regex groups as method parameters

### DIFF
--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/annotations/Group.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/annotations/Group.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2001-2005 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.bmsantos.core.cola.story.annotations;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(PARAMETER)
+public @interface Group {
+    public int value();
+}

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/processor/MethodDetails.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/processor/MethodDetails.java
@@ -23,102 +23,127 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.github.bmsantos.core.cola.story.annotations.Group;
 import com.github.bmsantos.core.cola.story.annotations.Projection;
 
 public class MethodDetails {
 
-    private final Method method;
-    private final List<String> projections;
-    private final Object[] arguments;
+	private final Method method;
+	private final List<String> projections;
+	private final Object[] arguments;
 
-    private MethodDetails(final Method method, final List<String> projections, final Object[] arguments) {
-        this.method = method;
-        this.projections = projections;
-        this.arguments = arguments;
-    }
+	private MethodDetails(final Method method, final List<String> projections, final Object[] arguments) {
+		this.method = method;
+		this.projections = projections;
+		this.arguments = arguments;
+	}
 
-    public Method getMethod() {
-        return method;
-    }
+	public Method getMethod() {
+		return method;
+	}
 
-    public boolean hasProjections() {
-        return projections != null && !projections.isEmpty();
-    }
+	public boolean hasProjections() {
+		return projections != null && !projections.isEmpty();
+	}
 
-    public List<String> getProjections() {
-        return projections;
-    }
+	public List<String> getProjections() {
+		return projections;
+	}
 
-    public Object[] getArguments() {
-        return arguments;
-    }
+	public Object[] getArguments() {
+		return arguments;
+	}
 
-    private static List<String> prepareProjections(final String step) {
+	private static List<String> prepareProjections(final String step) {
 
-        final List<String> results = new ArrayList<>();
+		final List<String> results = new ArrayList<>();
 
-        if (step != null) {
-            final Pattern pattern = Pattern.compile("<(.+?)>");
-            final Matcher matcher = pattern.matcher(step);
-            while (matcher.find()) {
-                results.add(matcher.group(1));
-            }
-        }
+		if (step != null) {
+			final Pattern pattern = Pattern.compile("<(.+?)>");
+			final Matcher matcher = pattern.matcher(step);
+			while (matcher.find()) {
+				results.add(matcher.group(1));
+			}
+		}
 
-        return results;
-    }
+		return results;
+	}
 
-    private static Object[] prepareArguments(final Method method, final List<String> projections,
-        final Map<String, String> projectionValues) {
+	private static List<String> prepareGroups(final String step, final Method method, final String annotationValue) {
 
-        final Annotation[][] params = method.getParameterAnnotations();
-        final Object[] args = new Object[params.length];
+		final List<String> results = new ArrayList<>();
 
-        if (projectionValues == null || projectionValues.isEmpty()) {
-            return args;
-        }
+		if (step != null && annotationValue != null) {
+			final Pattern pattern = Pattern.compile(annotationValue);
+			final Matcher matcher = pattern.matcher(step);
+			if (matcher.matches()) {
+				for( int i = 0; i <= matcher.groupCount(); i++ ) {
+					results.add(matcher.group(i));
+				}
+			}
+		}
 
-        final Class<?>[] types = method.getParameterTypes();
-        for (int i = 0; i < params.length; i++) {
-            args[i] = null;
-            for (final Annotation annotation : params[i]) {
-                if (annotation.annotationType().equals(Projection.class)) {
-                    final Projection projection = (Projection) annotation;
-                    if (projections.contains(projection.value())) {
-                        args[i] = generateValue(types[i], projectionValues.get(projection.value()));
-                    }
-                }
-            }
-        }
+		return results;
+	}
 
-        return args;
-    }
+	private static Object[] prepareArguments(final Method method, final List<String> projections,
+			final Map<String, String> projectionValues, final List<String> groups) {
 
-    private static Object generateValue(final Class<?> type, final String value) {
-        if (type.isAssignableFrom(String.class)) {
-            return value;
-        } else if (type.isAssignableFrom(Boolean.class)) {
-            return Boolean.valueOf(value);
-        } else if (type.isAssignableFrom(Byte.class)) {
-            return Byte.valueOf(value);
-        } else if (type.isAssignableFrom(Short.class)) {
-            return Short.valueOf(value);
-        } else if (type.isAssignableFrom(Integer.class)) {
-            return Integer.valueOf(value);
-        } else if (type.isAssignableFrom(Long.class)) {
-            return Long.valueOf(value);
-        } else if (type.isAssignableFrom(Float.class)) {
-            return Float.valueOf(value);
-        } else if (type.isAssignableFrom(Double.class)) {
-            return Double.valueOf(value);
-        }
-        return null;
-    }
+		final Annotation[][] params = method.getParameterAnnotations();
+		final Object[] args = new Object[params.length];
 
-    public static MethodDetails build(final Method method, final String step, final Map<String, String> projectionValues) {
-        final List<String> projections = prepareProjections(step);
-        final Object[] arguments = prepareArguments(method, projections, projectionValues);
+		if ((projectionValues == null || projectionValues.isEmpty()) && (groups == null || groups.isEmpty())) {
+			return args;
+		}
 
-        return new MethodDetails(method, projections, arguments);
-    }
+		final Class<?>[] types = method.getParameterTypes();
+		for (int i = 0; i < params.length; i++) {
+			args[i] = null;
+			for (final Annotation annotation : params[i]) {
+				if (annotation.annotationType().equals(Projection.class)) {
+					final Projection projection = (Projection) annotation;
+					if (projections.contains(projection.value())) {
+						args[i] = generateValue(types[i], projectionValues.get(projection.value()));
+					}
+				} else if (annotation.annotationType().equals(Group.class)) {
+					final Group group = (Group) annotation;
+					if (groups.size() > group.value()) {
+						args[i] = generateValue(types[i], groups.get(group.value()));
+					}
+				}
+			}
+		}
+
+		return args;
+	}
+
+	private static Object generateValue(final Class<?> type, final String value) {
+		if (type.isAssignableFrom(String.class)) {
+			return value;
+		} else if (type.isAssignableFrom(Boolean.class)) {
+			return Boolean.valueOf(value);
+		} else if (type.isAssignableFrom(Byte.class)) {
+			return Byte.valueOf(value);
+		} else if (type.isAssignableFrom(Short.class)) {
+			return Short.valueOf(value);
+		} else if (type.isAssignableFrom(Integer.class)) {
+			return Integer.valueOf(value);
+		} else if (type.isAssignableFrom(Long.class)) {
+			return Long.valueOf(value);
+		} else if (type.isAssignableFrom(Float.class)) {
+			return Float.valueOf(value);
+		} else if (type.isAssignableFrom(Double.class)) {
+			return Double.valueOf(value);
+		}
+		return null;
+	}
+
+	public static MethodDetails build(final Method method, final String step,
+			final Map<String, String> projectionValues, final String annotationValue) {
+		final List<String> projections = prepareProjections(step);
+		final List<String> groups = prepareGroups(step, method, annotationValue);
+		final Object[] arguments = prepareArguments(method, projections, projectionValues, groups);
+
+		return new MethodDetails(method, projections, arguments);
+	}
 }

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/processor/StoryProcessor.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/processor/StoryProcessor.java
@@ -113,8 +113,22 @@ public class StoryProcessor {
 
     private static MethodDetails findMethodWithAnnotation(final String type, final String step, final Method[] methods, final Map<String, String> projectionValues) {
         for (final Method method : methods) {
-            if (isGiven(type, step, method) || isWhen(type, step, method) || isThen(type, step, method)) {
-                return MethodDetails.build(method, step, projectionValues);
+        	boolean foundMethod = false;
+        	String annotationValue = null;
+            
+        	if (isGiven(type, step, method)) {
+            	foundMethod = true;
+            	annotationValue = method.getAnnotation(Given.class).value();
+            } else if (isWhen(type, step, method)) {
+            	foundMethod = true;
+            	annotationValue = method.getAnnotation(When.class).value();
+            } else if (isThen(type, step, method)) {
+            	foundMethod = true;
+            	annotationValue = method.getAnnotation(Then.class).value();
+            }
+            
+            if (foundMethod) {
+                return MethodDetails.build(method, step, projectionValues, annotationValue);
             }
         }
         return null;

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/story/processor/MethodDetailsTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/story/processor/MethodDetailsTest.java
@@ -13,6 +13,7 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.github.bmsantos.core.cola.story.annotations.Group;
 import com.github.bmsantos.core.cola.story.annotations.Projection;
 import com.github.bmsantos.core.cola.story.processor.MethodDetails;
 
@@ -20,19 +21,26 @@ public class MethodDetailsTest {
 
     private static final String STEP = "Given <pints> beers per <alcoholics> developers";
 
+    private static final String STEP_GROUPS = "Given 50 beers per 12 developers";
+
+    private static final String ANNOTATION_VALUE = "Given (\\d+) beers per (\\d+) developers";
+
     private MethodDetails uut;
 
     private Method method;
 
+    private Method methodGroups;
+
     @Before
     public void setUp() throws Exception {
         method = this.getClass().getMethod("given", new Class<?>[] { String.class, String.class });
+        methodGroups = this.getClass().getMethod("givenGroups", new Class<?>[] { Integer.class, Integer.class });
     }
 
     @Test
     public void shouldStoreMethod() {
         // Given
-        uut = MethodDetails.build(method, null, null);
+        uut = MethodDetails.build(method, null, null, null);
 
         // When
         final Method result = uut.getMethod();
@@ -44,7 +52,7 @@ public class MethodDetailsTest {
     @Test
     public void shouldPrepareStepProjections() {
         // Given
-        uut = MethodDetails.build(method, STEP, null);
+        uut = MethodDetails.build(method, STEP, null, null);
 
         // When
         final List<String> result = uut.getProjections();
@@ -60,7 +68,7 @@ public class MethodDetailsTest {
         projectionValues.put("pints", "100");
         projectionValues.put("alcoholics", "25");
 
-        uut = MethodDetails.build(method, STEP, projectionValues);
+        uut = MethodDetails.build(method, STEP, projectionValues, null);
 
         // When
         final Object[] result = uut.getArguments();
@@ -69,6 +77,21 @@ public class MethodDetailsTest {
         assertThat(asList(result), Matchers.contains((Object) "100", (Object) "25"));
     }
 
+    @Test
+    public void shouldPrepareGroupArguments() {
+        // Given
+        uut = MethodDetails.build(methodGroups, STEP_GROUPS, null, ANNOTATION_VALUE);
+
+        // When
+        final Object[] result = uut.getArguments();
+
+        // Then
+        assertThat(asList(result), Matchers.contains((Object) 50, (Object) 12));
+    }
+
     public void given(@Projection("pints") final String pints, @Projection("alcoholics") final String alcolholics) {
+    }
+
+    public void givenGroups(@Group(1) final Integer pints, @Group(2) final Integer alcolholics) {
     }
 }


### PR DESCRIPTION
Hi,

another small update. 

It is great that you accept regex, however there was no way to use capture groups to inject the value as method parameters. I had to use projections instead but that made my scenarios more complex to understand. 

The projections support is great when you want to run the same scenario with different values, but that's not what I needed. 

Let me know what you think.