### PR TITLE
Handle multiple compilation of the same test class

### DIFF
--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/main/ColaMainTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/main/ColaMainTest.java
@@ -3,6 +3,7 @@ package com.github.bmsantos.core.cola.main;
 import static com.github.bmsantos.core.cola.config.ConfigurationManager.config;
 import static java.io.File.separator;
 import static java.lang.String.format;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -104,8 +105,10 @@ public class ColaMainTest {
     @ConditionalIgnore(condition = RunningOnWindows.class)
     public void shouldNotProcessDefaultIdeBaseClass() throws ColaExecutionException {
         // Given
-        final File ideClass = new File(TARGET_DIR + separator + toOSPath(config.getProperty("default.ide.class")) + ".class");
-        final File renamedIdeClass = new File(TARGET_DIR + separator + toOSPath(config.getProperty("default.ide.class")) + "_renamed");
+        final File ideClass = new File(TARGET_DIR + separator + toOSPath(config.getProperty("default.ide.class"))
+            + ".class");
+        final File renamedIdeClass = new File(TARGET_DIR + separator
+            + toOSPath(config.getProperty("default.ide.class")) + "_renamed");
         ideClass.renameTo(renamedIdeClass);
 
         // When
@@ -138,7 +141,8 @@ public class ColaMainTest {
         uut.execute(provider);
 
         // Then
-        assertThat(logger.getLoggingEvents(), hasItem(info(config.info("processing") + TARGET_DIR + separator + ideClass + ".class")));
+        assertThat(logger.getLoggingEvents(), hasItem(info(config.info("processing") + TARGET_DIR + separator
+            + ideClass + ".class")));
     }
 
     // In order to have the following test pass the class has to be recompiled.
@@ -165,7 +169,7 @@ public class ColaMainTest {
     public void shouldProcessTestClasses() throws ColaExecutionException {
         // Given
         final File testClassFile = new File(TARGET_DIR + separator + testClass);
-        final long initialSize = testClass.length();
+        final long initialSize = testClassFile.length();
 
         // When
         uut.execute(provider);
@@ -203,6 +207,23 @@ public class ColaMainTest {
         // Then
         assertThat(uut.getFailures().size(), is(3));
         assertThat(logger.getLoggingEvents(), hasItem(error(format(config.error("failed.tests"), 3, 4))));
+    }
+
+    @Test
+    public void shouldHandlePreviouslyProcessedTestClasses() throws ColaExecutionException {
+        // Process the class once
+        uut.execute(provider);
+
+        // Given
+        final File testClassFile = new File(TARGET_DIR + separator + testClass);
+        final long initialSize = testClassFile.length();
+
+        // When
+        uut.execute(provider);
+        final long finalSize = testClassFile.length();
+
+        // Then
+        assertThat(finalSize, equalTo(initialSize));
     }
 
     private static String toOSPath(final String value) {


### PR DESCRIPTION
Hi,

While I was working in eclipse using your cola-tests library with the maven plugin, I often had the following error when I modified a feature file and tried to run the tests again:

```
java.lang.ClassFormatError: Duplicate method name&signature in class file com/github/dcendents/mybatis/generator/plugin/client/AlterResultMapPluginTest
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:800)
	at ...
```

To fix the problem I would do a maven update of the project (Alt-F5) every time before I run the tests.


The problem is that new methods are added to the test class for each scenario, but there is no check to make sure the method did not already exist.

I've modified the code to first remove all methods that match the pattern you use (feature : scenario) which fixes the duplicate method error I had. It should also fix the problem where a scenario is deleted from the feature file but it was still present in the test class.

Again let me know what you think. 
I've also modified my format settings on the project to try and match yours! ;-)

Cheers,
Dan