### PR TITLE
Introduce cola instrument

### DIFF
--- a/cola-tests/pom.xml
+++ b/cola-tests/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -96,7 +97,24 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Premain-Class>com.github.bmsantos.core.cola.instrument.ColaInstrument</Premain-Class>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/instrument/ColaInstrument.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/instrument/ColaInstrument.java
@@ -1,0 +1,9 @@
+package com.github.bmsantos.core.cola.instrument;
+
+import java.lang.instrument.Instrumentation;
+
+public class ColaInstrument {
+    public static void premain(final String agentArgs, final Instrumentation instrumentation) {
+        instrumentation.addTransformer(new ColaTransformer());
+    }
+}

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/instrument/ColaTransformer.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/instrument/ColaTransformer.java
@@ -1,0 +1,37 @@
+package com.github.bmsantos.core.cola.instrument;
+
+import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
+import static org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.IllegalClassFormatException;
+import java.security.ProtectionDomain;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+
+import com.github.bmsantos.core.cola.injector.InfoClassVisitor;
+import com.github.bmsantos.core.cola.injector.InjectorClassVisitor;
+
+public class ColaTransformer implements ClassFileTransformer {
+
+    @Override
+    public byte[] transform(final ClassLoader classLoader, final String className, final Class<?> classBeingRedefined,
+        final ProtectionDomain protectionDomain, final byte[] classfileBuffer) throws IllegalClassFormatException {
+
+        try {
+
+            final ClassReader reader = new ClassReader(classfileBuffer);
+            final ClassWriter writer = new ClassWriter(reader, COMPUTE_FRAMES | COMPUTE_MAXS);
+            final InfoClassVisitor info = new InfoClassVisitor(writer, classLoader);
+            final InjectorClassVisitor injector = new InjectorClassVisitor(info);
+            reader.accept(injector, 0);
+
+            return writer.toByteArray();
+        } catch (final Throwable t) {
+            // empty
+        }
+
+        return classfileBuffer;
+    }
+}

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/utils/ColaUtils.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/utils/ColaUtils.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 public final class ColaUtils {
 
+    public static final String RESOURCE_SEPARATOR = "/";
     public static final String CLASS_EXT = ".class";
 
     public static boolean isSet(final String value) {
@@ -67,12 +68,24 @@ public final class ColaUtils {
         return result;
     }
 
+    public static String binaryToResource(final String binaryFormat) {
+        return binaryFormat.replace(".", RESOURCE_SEPARATOR);
+    }
+
+    public static String binaryToResourceClass(final String binaryFormat) {
+        String result = binaryToResource(binaryFormat);
+        if (!isClassFile(result)) {
+            result += CLASS_EXT;
+        }
+        return result;
+    }
+
     public static boolean binaryFileExists(final String dir, final String clazz) {
         return isSet(dir) && isSet(clazz) && new File(dir + separator + binaryToOsClass(clazz)).exists();
     }
 
     public static String toOSPath(final String path) {
-        return path.replace("/", separator).replace("\\", separator);
+        return path.replace(RESOURCE_SEPARATOR, separator).replace("\\", separator);
     }
 
     public static String paramEncoding(final String original) throws UnsupportedEncodingException {

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/instrument/ColaInstrumentTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/instrument/ColaInstrumentTest.java
@@ -1,0 +1,27 @@
+package com.github.bmsantos.core.cola.instrument;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.lang.instrument.Instrumentation;
+
+import org.junit.Test;
+
+public class ColaInstrumentTest {
+
+    private static final String NO_ARGS = null;
+
+    @Test
+    public void shouldAddTransformer() {
+        // Given
+        final Instrumentation instrumentation = mock(Instrumentation.class);
+
+        // When
+        ColaInstrument.premain(NO_ARGS, instrumentation);
+
+        // Then
+        verify(instrumentation).addTransformer(any(ColaTransformer.class));
+    }
+
+}

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/instrument/ColaTransformerTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/instrument/ColaTransformerTest.java
@@ -1,0 +1,49 @@
+package com.github.bmsantos.core.cola.instrument;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static test.utils.TestUtils.loadClassBytes;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import test.utils.StoriesFieldClass;
+
+public class ColaTransformerTest {
+
+    private ColaTransformer uut;
+
+    @Before
+    public void setUp() {
+        uut = new ColaTransformer();
+    }
+
+    @Test
+    public void shouldTransformClass() throws Exception {
+        // Given
+        final Class<?> clazz = StoriesFieldClass.class;
+        final byte[] original = loadClassBytes(clazz);
+
+        // When
+        final byte[] result = uut.transform(ColaTransformer.class.getClassLoader(), clazz.getName(), clazz, null,
+            original);
+
+        // Then
+        assertThat(result, not(equalTo(original)));
+    }
+
+    @Test
+    public void shouldNotTransformClass() throws Exception {
+        // Given
+        final Class<?> clazz = ColaTransformerTest.class;
+        final byte[] original = loadClassBytes(clazz);
+
+        // When
+        final byte[] result = uut.transform(ColaTransformer.class.getClassLoader(), clazz.getName(), clazz, null,
+            original);
+
+        // Then
+        assertThat(result, equalTo(original));
+    }
+}

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/utils/ColaUtilsTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/utils/ColaUtilsTest.java
@@ -1,8 +1,11 @@
 package com.github.bmsantos.core.cola.utils;
 
+import static com.github.bmsantos.core.cola.utils.ColaUtils.RESOURCE_SEPARATOR;
 import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryFileExists;
 import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryToOS;
 import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryToOsClass;
+import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryToResource;
+import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryToResourceClass;
 import static com.github.bmsantos.core.cola.utils.ColaUtils.classToBinary;
 import static com.github.bmsantos.core.cola.utils.ColaUtils.isSet;
 import static com.github.bmsantos.core.cola.utils.ColaUtils.osToBinary;
@@ -14,8 +17,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
-
-import com.github.bmsantos.core.cola.utils.ColaUtils;
 
 public class ColaUtilsTest {
 
@@ -177,6 +178,19 @@ public class ColaUtilsTest {
     }
 
     @Test
+    public void shouldConvertToResource() {
+        // Given
+        final String path = toBinary("com", "github", "bmsantos", "MyClass");
+        final String expected = path.replace(".", RESOURCE_SEPARATOR);
+
+        // When
+        final String result = binaryToResource(path);
+
+        // Then
+        assertThat(result, is(expected));
+    }
+
+    @Test
     public void shouldConvertToOSClass() {
         // Given
         final String path = toBinary("com", "github", "bmsantos", "MyClass");
@@ -184,6 +198,19 @@ public class ColaUtilsTest {
 
         // When
         final String result = binaryToOsClass(path);
+
+        // Then
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    public void shouldConvertToResourceClass() {
+        // Given
+        final String path = toBinary("com", "github", "bmsantos", "MyClass");
+        final String expected = path.replace(".", RESOURCE_SEPARATOR) + ".class";
+
+        // When
+        final String result = binaryToResourceClass(path);
 
         // Then
         assertThat(result, is(expected));

--- a/cola-tests/src/test/java/test/utils/StoriesFieldClass.java
+++ b/cola-tests/src/test/java/test/utils/StoriesFieldClass.java
@@ -1,0 +1,10 @@
+package test.utils;
+
+public class StoriesFieldClass {
+    private final String stories =
+        "Feature: Load feature from default field\n"
+            + "Scenario: Should have scenario steps\n"
+            + "Given A\n"
+            + "When B\n"
+            + "Then C\n";
+}

--- a/cola-tests/src/test/java/test/utils/TestUtils.java
+++ b/cola-tests/src/test/java/test/utils/TestUtils.java
@@ -1,11 +1,14 @@
 package test.utils;
 
+import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryToOsClass;
 import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
 import static org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 
+import org.codehaus.plexus.util.IOUtil;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 
@@ -23,6 +26,11 @@ public class TestUtils {
         cr.accept(classVisitor, 0);
 
         return classVisitor.getFeatures();
+    }
+
+    public static byte[] loadClassBytes(final Class<?> clazz) throws IOException {
+        final InputStream is = clazz.getClassLoader().getResourceAsStream(binaryToOsClass(clazz.getName()));
+        return IOUtil.toByteArray(is);
     }
 
 }


### PR DESCRIPTION
Added ColaInstrument, ColaTransformer and respective unit tests.

This commits allows cola-test to be executed as a JVM instrument, meaning that cola-maven-plugin, gradle-maven-plugin and IDEA plugin are not required when the agent is setup.

In maven would be something like:
```xml
            <plugin>
                <artifactId>maven-failsafe-plugin</artifactId>
                <version>2.17</version>
                <configuration>
                    <argLine>-javaagent:${settings.localRepository}/com/github/bmsantos/cola-tests/${cola.version}/cola-tests-${cola.version}.jar</argLine>
                    <skip>true</skip>
                </configuration>
                <executions>
                    <execution>
                        <id>integration-tests</id>
                        <phase>integration-test</phase>
                        <goals>
                            <goal>integration-test</goal>
                            <goal>verify</goal>
                        </goals>
                        <configuration>
                            <skip>false</skip>
                            <includes>
                                <include>**/*Test.java</include>
                            </includes>
                        </configuration>
                    </execution>
                </executions>
            </plugin>
```

Another option is to use the the default JAVA_TOOL_OPTIONS environment variable (this option was not tested yet):

```bash
JAVA_TOOL_OPTIONS="-javaagent:/path/to/my/.m2/repository/com/github/bmsantos/cola-tests/0.3.1-SNAPSHOT/cola-tests-0.3.1-SNAPSHOT.jar"
```

Issue #24