### PR TITLE
Introduce @IdeEnabler

### DIFF
--- a/cola-tests/pom.xml
+++ b/cola-tests/pom.xml
@@ -53,6 +53,11 @@
             <groupId>uk.org.lidalia</groupId>
             <artifactId>slf4j-test</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-util</artifactId>
+            <version>5.0.4</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -117,6 +122,41 @@
                 </executions>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>
+                                            org.apache.maven.plugins
+                                        </groupId>
+                                        <artifactId>
+                                            maven-jar-plugin
+                                        </artifactId>
+                                        <versionRange>
+                                            [2.6,)
+                                        </versionRange>
+                                        <goals>
+                                            <goal>jar</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <scm>

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/injector/MethodRemoverClassVisitor.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/injector/MethodRemoverClassVisitor.java
@@ -15,22 +15,26 @@
  */
 package com.github.bmsantos.core.cola.injector;
 
+import static java.util.Objects.requireNonNull;
+import static org.objectweb.asm.Opcodes.ASM4;
+
+import java.util.List;
+
 import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 
 public class MethodRemoverClassVisitor extends ClassVisitor {
 
-    private final String methodToRemove;
+    private final List<String> methodsToRemove;
 
-    public MethodRemoverClassVisitor(final int api, final ClassWriter cw, final String methodToRemove) {
-        super(api, cw);
-        this.methodToRemove = methodToRemove;
+    public MethodRemoverClassVisitor(final ClassVisitor cv, final List<String> methodsToRemove) {
+        super(ASM4, cv);
+        this.methodsToRemove = requireNonNull(methodsToRemove);
     }
 
     @Override
     public MethodVisitor visitMethod(final int access, final String name, final String desc, final String signature, final String[] exceptions) {
-        if (name.equals(methodToRemove)) {
+        if (methodsToRemove.contains(name)) {
             return null;
         }
         return super.visitMethod(access, name, desc, signature, exceptions);

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/instrument/ColaTransformer.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/instrument/ColaTransformer.java
@@ -1,5 +1,6 @@
 package com.github.bmsantos.core.cola.instrument;
 
+import static java.util.Arrays.copyOf;
 import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
 import static org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
 
@@ -12,26 +13,45 @@ import org.objectweb.asm.ClassWriter;
 
 import com.github.bmsantos.core.cola.injector.InfoClassVisitor;
 import com.github.bmsantos.core.cola.injector.InjectorClassVisitor;
+import com.github.bmsantos.core.cola.injector.MethodRemoverClassVisitor;
 
 public class ColaTransformer implements ClassFileTransformer {
+
+    private static final int WRITER_FLAGS = COMPUTE_FRAMES | COMPUTE_MAXS;
 
     @Override
     public byte[] transform(final ClassLoader classLoader, final String className, final Class<?> classBeingRedefined,
         final ProtectionDomain protectionDomain, final byte[] classfileBuffer) throws IllegalClassFormatException {
 
+        final byte[] instrumentedBuffer = copyOf(classfileBuffer, classfileBuffer.length);
+
         try {
 
-            final ClassReader reader = new ClassReader(classfileBuffer);
-            final ClassWriter writer = new ClassWriter(reader, COMPUTE_FRAMES | COMPUTE_MAXS);
+            final ClassReader reader = new ClassReader(instrumentedBuffer);
+            final ClassWriter writer = new ClassWriter(reader, WRITER_FLAGS);
             final InfoClassVisitor info = new InfoClassVisitor(writer, classLoader);
             final InjectorClassVisitor injector = new InjectorClassVisitor(info);
             reader.accept(injector, 0);
 
-            return writer.toByteArray();
+            if (!info.getIdeEnabledMethods().isEmpty()) {
+                return removeMethods(writer, info);
+            }
+
+            if (!info.getFeatures().isEmpty() || !info.getIdeEnabledMethods().isEmpty()) {
+                return writer.toByteArray();
+            }
         } catch (final Throwable t) {
             // empty
         }
 
         return classfileBuffer;
+    }
+
+    private byte[] removeMethods(final ClassWriter writer, final InfoClassVisitor info) {
+        final ClassReader rreader = new ClassReader(writer.toByteArray());
+        final ClassWriter rwriter = new ClassWriter(rreader, WRITER_FLAGS);
+        final MethodRemoverClassVisitor remover = new MethodRemoverClassVisitor(rwriter, info.getIdeEnabledMethods());
+        rreader.accept(remover, 0);
+        return rwriter.toByteArray();
     }
 }

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/instrument/ColaTransformer.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/instrument/ColaTransformer.java
@@ -7,6 +7,8 @@ import static org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.security.ProtectionDomain;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -18,6 +20,12 @@ import com.github.bmsantos.core.cola.injector.MethodRemoverClassVisitor;
 public class ColaTransformer implements ClassFileTransformer {
 
     private static final int WRITER_FLAGS = COMPUTE_FRAMES | COMPUTE_MAXS;
+
+    private final List<String> methodsToRemove = new ArrayList<>();
+
+    public void removeMethod(final String methodName) {
+        methodsToRemove.add(methodName);
+    }
 
     @Override
     public byte[] transform(final ClassLoader classLoader, final String className, final Class<?> classBeingRedefined,
@@ -32,6 +40,8 @@ public class ColaTransformer implements ClassFileTransformer {
             final InfoClassVisitor info = new InfoClassVisitor(writer, classLoader);
             final InjectorClassVisitor injector = new InjectorClassVisitor(info);
             reader.accept(injector, 0);
+
+            info.getIdeEnabledMethods().addAll(methodsToRemove);
 
             if (!info.getIdeEnabledMethods().isEmpty()) {
                 return removeMethods(writer, info);

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/main/ColaMain.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/main/ColaMain.java
@@ -20,8 +20,7 @@ import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryFileExists;
 import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryToOsClass;
 import static com.github.bmsantos.core.cola.utils.ColaUtils.isSet;
 import static java.lang.String.format;
-import static java.util.Arrays.asList;
-import static org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
+import static org.codehaus.plexus.util.IOUtil.toByteArray;
 
 import java.io.DataOutputStream;
 import java.io.File;
@@ -30,16 +29,11 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.ClassWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.bmsantos.core.cola.exceptions.ColaExecutionException;
-import com.github.bmsantos.core.cola.injector.InfoClassVisitor;
-import com.github.bmsantos.core.cola.injector.InjectorClassVisitor;
-import com.github.bmsantos.core.cola.injector.MethodRemoverClassVisitor;
+import com.github.bmsantos.core.cola.instrument.ColaTransformer;
 import com.github.bmsantos.core.cola.provider.IColaProvider;
 
 public class ColaMain {
@@ -86,13 +80,7 @@ public class ColaMain {
 
         for (final String className : targetClasses) {
             try {
-                final ClassWriter classWritter = new ClassWriter(COMPUTE_MAXS);
-
-                final InfoClassVisitor infoClassVisitor = new InfoClassVisitor(classWritter, provider.getTargetClassLoader());
-
-                final InjectorClassVisitor injectorClassVisitor = new InjectorClassVisitor(infoClassVisitor);
-
-                processClass(className, classWritter, injectorClassVisitor);
+                processClass(className, null);
             } catch (final Throwable t) {
                 log.error(format(config.error("failed.process.file"), className), t);
                 failures.add(format(config.error("failed.processing"), className, t.getMessage()));
@@ -113,10 +101,7 @@ public class ColaMain {
 
         ideBaseClass = binaryToOsClass(ideBaseClass);
 
-        final ClassWriter cw = new ClassWriter(COMPUTE_MAXS);
-        final MethodRemoverClassVisitor remover = new MethodRemoverClassVisitor(cw, asList(ideTestMethod));
-
-        processClass(ideBaseClass, cw, remover);
+        processClass(ideBaseClass, ideTestMethod);
 
         return ideBaseClass;
     }
@@ -145,19 +130,21 @@ public class ColaMain {
         return false;
     }
 
-    private void processClass(final String className, final ClassWriter cw, final ClassVisitor classVisitor)
+    private void processClass(final String className, final String methodToRemove)
         throws Exception {
 
         final String filePath = provider.getTargetDirectory() + className;
         log.info(config.info("processing") + filePath);
 
         final InputStream in = provider.getTargetClassLoader().getResourceAsStream(className);
-        final ClassReader classReader = new ClassReader(in);
-        classReader.accept(classVisitor, 0);
+
+        final ColaTransformer transformer = new ColaTransformer();
+        transformer.removeMethod(methodToRemove);
+        final byte[] instrumented = transformer.transform(provider.getTargetClassLoader(), null, null, null, toByteArray(in));
 
         final File file = new File(filePath);
         try (final DataOutputStream dout = new DataOutputStream(new FileOutputStream(file))) {
-            dout.write(cw.toByteArray());
+            dout.write(instrumented);
         }
     }
 }

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/main/ColaMain.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/main/ColaMain.java
@@ -20,8 +20,8 @@ import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryFileExists;
 import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryToOsClass;
 import static com.github.bmsantos.core.cola.utils.ColaUtils.isSet;
 import static java.lang.String.format;
+import static java.util.Arrays.asList;
 import static org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
-import static org.objectweb.asm.Opcodes.ASM4;
 
 import java.io.DataOutputStream;
 import java.io.File;
@@ -114,7 +114,7 @@ public class ColaMain {
         ideBaseClass = binaryToOsClass(ideBaseClass);
 
         final ClassWriter cw = new ClassWriter(COMPUTE_MAXS);
-        final MethodRemoverClassVisitor remover = new MethodRemoverClassVisitor(ASM4, cw, ideTestMethod);
+        final MethodRemoverClassVisitor remover = new MethodRemoverClassVisitor(cw, asList(ideTestMethod));
 
         processClass(ideBaseClass, cw, remover);
 

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/annotations/IdeEnabler.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/annotations/IdeEnabler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2001-2005 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.bmsantos.core.cola.story.annotations;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface IdeEnabler {
+}

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/injector/InfoClassVisitorTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/injector/InfoClassVisitorTest.java
@@ -1,5 +1,7 @@
 package com.github.bmsantos.core.cola.injector;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
@@ -7,6 +9,7 @@ import static org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
 
 import java.io.IOException;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -85,7 +88,7 @@ public class InfoClassVisitorTest {
         // Then
         assertThat(uut.getFeatures().size(), is(2));
     }
-    
+
     @Test
     public void shouldRetrieveComplexClass() throws IOException {
         // Given
@@ -139,6 +142,45 @@ public class InfoClassVisitorTest {
         cr.accept(uut, 0);
     }
     
+    @Test
+    public void shouldListIdeEnabledMethod() throws IOException {
+        // Given
+        final ClassWriter cw = initClassWriterFor("test.utils.IdeEnablerClass");
+        uut = new InfoClassVisitor(cw, getClass().getClassLoader());
+
+        // When
+        cr.accept(uut, 0);
+
+        // Then
+        assertThat(uut.getIdeEnabledMethods(), hasItem("shouldBeRemoved"));
+    }
+
+    @Test
+    public void shouldListAllIdeEnabledMethods() throws IOException {
+        // Given
+        final ClassWriter cw = initClassWriterFor("test.utils.MultipleIdeEnablerClass");
+        uut = new InfoClassVisitor(cw, getClass().getClassLoader());
+
+        // When
+        cr.accept(uut, 0);
+
+        // Then
+        assertThat(uut.getIdeEnabledMethods(), contains("shouldBeRemoved1", "shouldBeRemoved2"));
+    }
+
+    @Test
+    public void shouldNotHaveIdeEnabledMethods() throws IOException {
+        // Given
+        final ClassWriter cw = initClassWriterFor("test.utils.StoriesFieldClass");
+        uut = new InfoClassVisitor(cw, getClass().getClassLoader());
+
+        // When
+        cr.accept(uut, 0);
+
+        // Then
+        assertThat(uut.getIdeEnabledMethods().size(), is(0));
+    }
+
     private ClassWriter initClassWriterFor(final String className) throws IOException {
         cr = new ClassReader(className);
         final ClassWriter cw = new ClassWriter(cr, COMPUTE_FRAMES | COMPUTE_MAXS);

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/injector/MethodRemoverClassVisitorTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/injector/MethodRemoverClassVisitorTest.java
@@ -1,0 +1,54 @@
+package com.github.bmsantos.core.cola.injector;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
+import static org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.util.TraceClassVisitor;
+
+public class MethodRemoverClassVisitorTest {
+
+    private static final String METHOD_TO_REMOVE = "shouldBeRemoved";
+
+    private ClassReader cr;
+    private MethodRemoverClassVisitor uut;
+    private ByteArrayOutputStream capture;
+
+    @Before
+    public void init() {
+        capture = new ByteArrayOutputStream();
+    }
+
+    @Test
+    public void shouldRetrieveDefaultField() throws IOException {
+        // Given
+        final ClassVisitor cw = initClassWriterFor("test.utils.IdeEnablerClass");
+        uut = new MethodRemoverClassVisitor(cw, asList(METHOD_TO_REMOVE));
+
+        // When
+        cr.accept(uut, 0);
+
+        // Then
+        assertThat(capture.toString(), not(containsString(METHOD_TO_REMOVE)));
+    }
+
+    private ClassVisitor initClassWriterFor(final String className) throws IOException {
+        cr = new ClassReader(className);
+        final ClassWriter cw = new ClassWriter(cr, COMPUTE_FRAMES | COMPUTE_MAXS);
+        final TraceClassVisitor tcv = new TraceClassVisitor(cw, new PrintWriter(new PrintStream(capture), true));
+        return tcv;
+    }
+}

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/instrument/ColaTransformerTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/instrument/ColaTransformerTest.java
@@ -1,13 +1,16 @@
 package com.github.bmsantos.core.cola.instrument;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static test.utils.TestUtils.loadClassBytes;
+import static test.utils.TestUtils.traceBytecode;
 
 import org.junit.Before;
 import org.junit.Test;
 
+import test.utils.MultipleIdeEnablerClass;
 import test.utils.StoriesFieldClass;
 
 public class ColaTransformerTest {
@@ -26,11 +29,12 @@ public class ColaTransformerTest {
         final byte[] original = loadClassBytes(clazz);
 
         // When
-        final byte[] result = uut.transform(ColaTransformer.class.getClassLoader(), clazz.getName(), clazz, null,
-            original);
+        final byte[] result = uut.transform(ColaTransformer.class.getClassLoader(), clazz.getName(), clazz, null, original);
 
         // Then
         assertThat(result, not(equalTo(original)));
+        final String trace = traceBytecode(result);
+        assertThat(trace, containsString("@Lorg/junit/Test;()"));
     }
 
     @Test
@@ -40,10 +44,25 @@ public class ColaTransformerTest {
         final byte[] original = loadClassBytes(clazz);
 
         // When
-        final byte[] result = uut.transform(ColaTransformer.class.getClassLoader(), clazz.getName(), clazz, null,
-            original);
+        final byte[] result = uut.transform(ColaTransformer.class.getClassLoader(), clazz.getName(), clazz, null, original);
 
         // Then
         assertThat(result, equalTo(original));
+    }
+
+    @Test
+    public void shouldRemoveTransformClass() throws Exception {
+        // Given
+        final Class<?> clazz = MultipleIdeEnablerClass.class;
+        final byte[] original = loadClassBytes(clazz);
+
+        // When
+        final byte[] result = uut.transform(ColaTransformer.class.getClassLoader(), clazz.getName(), clazz, null, original);
+
+        // Then
+        assertThat(result, not(equalTo(original)));
+        final String trace = traceBytecode(result);
+        assertThat(trace, not(containsString("shouldBeRemoved1")));
+        assertThat(trace, not(containsString("shouldBeRemoved2")));
     }
 }

--- a/cola-tests/src/test/java/test/utils/IdeEnablerClass.java
+++ b/cola-tests/src/test/java/test/utils/IdeEnablerClass.java
@@ -1,0 +1,15 @@
+package test.utils;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import com.github.bmsantos.core.cola.story.annotations.IdeEnabler;
+
+public class IdeEnablerClass {
+    @IdeEnabler
+    @Test
+    public void shouldBeRemoved() {
+        fail("This method should be removed");
+    }
+}

--- a/cola-tests/src/test/java/test/utils/MultipleIdeEnablerClass.java
+++ b/cola-tests/src/test/java/test/utils/MultipleIdeEnablerClass.java
@@ -1,0 +1,21 @@
+package test.utils;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import com.github.bmsantos.core.cola.story.annotations.IdeEnabler;
+
+public class MultipleIdeEnablerClass {
+    @IdeEnabler
+    @Test
+    public void shouldBeRemoved1() {
+        fail("This method should be removed");
+    }
+
+    @IdeEnabler
+    @Test
+    public void shouldBeRemoved2() {
+        fail("This method should be removed");
+    }
+}

--- a/cola-tests/src/test/java/test/utils/TestUtils.java
+++ b/cola-tests/src/test/java/test/utils/TestUtils.java
@@ -4,22 +4,28 @@ import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryToOsClass;
 import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
 import static org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
 import java.util.List;
 
 import org.codehaus.plexus.util.IOUtil;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.util.TraceClassVisitor;
 
 import com.github.bmsantos.core.cola.formatter.FeatureDetails;
 import com.github.bmsantos.core.cola.injector.InfoClassVisitor;
 
 public class TestUtils {
 
+    private static final int WRITER_FLAGS = COMPUTE_FRAMES | COMPUTE_MAXS;
+
     public static List<FeatureDetails> loadFeatures(final String className) throws IOException {
         final ClassReader cr = new ClassReader(className);
-        final ClassWriter cw = new ClassWriter(cr, COMPUTE_FRAMES | COMPUTE_MAXS);
+        final ClassWriter cw = new ClassWriter(cr, WRITER_FLAGS);
         final InfoClassVisitor classVisitor = new InfoClassVisitor(cw, Thread.currentThread().getContextClassLoader());
 
         // When
@@ -33,4 +39,12 @@ public class TestUtils {
         return IOUtil.toByteArray(is);
     }
 
+    public static String traceBytecode(final byte[] bytecode) {
+        final ClassReader cr = new ClassReader(bytecode);
+        final ClassWriter cw = new ClassWriter(cr, WRITER_FLAGS);
+        final ByteArrayOutputStream capture = new ByteArrayOutputStream();
+        final TraceClassVisitor tcv = new TraceClassVisitor(cw, new PrintWriter(new PrintStream(capture), true));
+        cr.accept(tcv, 0);
+        return capture.toString();
+    }
 }


### PR DESCRIPTION
The @IdeEnabler annotation is used to identify methods used to enable the cola-test execution in an IDE JUnit Runner. As such, any method annotated with @IdeEnabler will be skipped from the JUnit  POJO execution.

- Added @IdeEnabler annotation
- Introduced method detection mechanism
- Introduced multiple method removal
- Updated transformer
- Updated ColaMain
