### PR TITLE
Should filter test classes

### DIFF
--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/instrument/ColaTransformer.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/instrument/ColaTransformer.java
@@ -1,5 +1,6 @@
 package com.github.bmsantos.core.cola.instrument;
 
+import static java.lang.System.getProperty;
 import static java.util.Arrays.copyOf;
 import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
 import static org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
@@ -32,6 +33,10 @@ public class ColaTransformer implements ClassFileTransformer {
     @Override
     public byte[] transform(final ClassLoader classLoader, final String className, final Class<?> classBeingRedefined,
         final ProtectionDomain protectionDomain, final byte[] classfileBuffer) throws IllegalClassFormatException {
+
+        if (!isTestClass(className)) {
+            return classfileBuffer;
+        }
 
         final byte[] instrumentedBuffer = copyOf(classfileBuffer, classfileBuffer.length);
 
@@ -75,5 +80,15 @@ public class ColaTransformer implements ClassFileTransformer {
         final ErrorsClassVisitor injector = new ErrorsClassVisitor(writer, t.getMessage());
         reader.accept(injector, 0);
         return writer.toByteArray();
+    }
+
+    private boolean isTestClass(final String className) {
+        final String filters = getProperty("colaTests", ".*Test");
+        for (final String filter : filters.split(",")) {
+            if (className.matches(filter)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/main/ColaMain.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/main/ColaMain.java
@@ -19,6 +19,7 @@ import static com.github.bmsantos.core.cola.config.ConfigurationManager.config;
 import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryFileExists;
 import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryToOsClass;
 import static com.github.bmsantos.core.cola.utils.ColaUtils.isSet;
+import static com.github.bmsantos.core.cola.utils.ColaUtils.resourceClassToResource;
 import static java.lang.String.format;
 import static org.codehaus.plexus.util.IOUtil.toByteArray;
 
@@ -35,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import com.github.bmsantos.core.cola.exceptions.ColaExecutionException;
 import com.github.bmsantos.core.cola.instrument.ColaTransformer;
 import com.github.bmsantos.core.cola.provider.IColaProvider;
+import com.github.bmsantos.core.cola.utils.ColaUtils;
 
 public class ColaMain {
 
@@ -140,7 +142,7 @@ public class ColaMain {
 
         final ColaTransformer transformer = new ColaTransformer();
         transformer.removeMethod(methodToRemove);
-        final byte[] instrumented = transformer.transform(provider.getTargetClassLoader(), null, null, null, toByteArray(in));
+        final byte[] instrumented = transformer.transform(provider.getTargetClassLoader(), resourceClassToResource(className), null, null, toByteArray(in));
 
         final File file = new File(filePath);
         try (final DataOutputStream dout = new DataOutputStream(new FileOutputStream(file))) {

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/utils/ColaUtils.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/utils/ColaUtils.java
@@ -80,6 +80,10 @@ public final class ColaUtils {
         return result;
     }
 
+    public static String resourceClassToResource(final String resourceClass) {
+        return resourceClass.replace(CLASS_EXT, "");
+    }
+
     public static boolean binaryFileExists(final String dir, final String clazz) {
         return isSet(dir) && isSet(clazz) && new File(dir + separator + binaryToOsClass(clazz)).exists();
     }

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/instrument/ColaTransformerTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/instrument/ColaTransformerTest.java
@@ -1,5 +1,6 @@
 package com.github.bmsantos.core.cola.instrument;
 
+import static java.lang.System.setProperty;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -20,6 +21,7 @@ public class ColaTransformerTest {
 
     @Before
     public void setUp() {
+        setProperty("colaTests", ".*Test");
         uut = new ColaTransformer();
     }
 
@@ -80,5 +82,33 @@ public class ColaTransformerTest {
         assertThat(result, not(equalTo(original)));
         final String trace = traceBytecode(result);
         assertThat(trace, containsString("Cola Tests : Compilation Errors"));
+    }
+
+    @Test
+    public void shouldSetColaTestsFilterProperty() throws Exception {
+        // Given
+        setProperty("colaTests", ".*Foo");
+        final Class<?> clazz = StoriesFieldTest.class;
+        final byte[] original = loadClassBytes(clazz);
+
+        // When
+        final byte[] result = uut.transform(ColaTransformer.class.getClassLoader(), clazz.getName(), clazz, null, original);
+
+        // Then
+        assertThat(result, equalTo(original));
+    }
+
+    @Test
+    public void shouldAllowMultipleFilters() throws Exception {
+        // Given
+        setProperty("colaTests", ".*FooTest,.*FieldTest");
+        final Class<?> clazz = StoriesFieldTest.class;
+        final byte[] original = loadClassBytes(clazz);
+
+        // When
+        final byte[] result = uut.transform(ColaTransformer.class.getClassLoader(), clazz.getName(), clazz, null, original);
+
+        // Then
+        assertThat(result, not(equalTo(original)));
     }
 }

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/instrument/ColaTransformerTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/instrument/ColaTransformerTest.java
@@ -85,7 +85,7 @@ public class ColaTransformerTest {
     }
 
     @Test
-    public void shouldSetColaTestsFilterProperty() throws Exception {
+    public void shouldSetColaTestsFilterPropertyAndSkipNonmatchingClass() throws Exception {
         // Given
         setProperty("colaTests", ".*Foo");
         final Class<?> clazz = StoriesFieldTest.class;
@@ -96,6 +96,20 @@ public class ColaTransformerTest {
 
         // Then
         assertThat(result, equalTo(original));
+    }
+    
+    @Test
+    public void shouldSetColaTestsFilterPropertyAndFilterMatchingClass() throws Exception {
+        // Given
+        setProperty("colaTests", ".*FieldTest");
+        final Class<?> clazz = StoriesFieldTest.class;
+        final byte[] original = loadClassBytes(clazz);
+
+        // When
+        final byte[] result = uut.transform(ColaTransformer.class.getClassLoader(), clazz.getName(), clazz, null, original);
+
+        // Then
+        assertThat(result, not(equalTo(original)));
     }
 
     @Test

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/main/ColaMainTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/main/ColaMainTest.java
@@ -194,9 +194,9 @@ public class ColaMainTest {
     @Test
     public void shouldCollectFailureHistory() {
         // Given
-        classes.add(toOSPath("this/path/takes/to/nowhere/NotFountTest1.class"));
-        classes.add(toOSPath("this/path/takes/to/nowhere/NotFountTest2.class"));
-        classes.add(toOSPath("this/path/takes/to/nowhere/NotFountTest3.class"));
+        classes.add(toOSPath("this/path/takes/to/nowhere/NotFount1Test.class"));
+        classes.add(toOSPath("this/path/takes/to/nowhere/NotFount2Test.class"));
+        classes.add(toOSPath("this/path/takes/to/nowhere/NotFount3Test.class"));
 
         // When
         try {


### PR DESCRIPTION
- Introduced a system property named "colaTests" that accepts a comma-separated list of regular expressions.
- Classes that do not fall within an expression will not be processed.
- Default filter is set to accept all class names terminating in "Test".

Issue #30