### PR TITLE
Remove default IDE settings

### DIFF
--- a/cola-tests-compiler/src/main/java/com/github/bmsantos/compiler/cola/Application.java
+++ b/cola-tests-compiler/src/main/java/com/github/bmsantos/compiler/cola/Application.java
@@ -41,12 +41,6 @@ public class Application {
         description = "Base directory containing compiled java packages and classes (required)")
     private String targetDirectory;
 
-    @Parameter(names = { "-b", "--ideBaseClass" }, description = "IDE base test class if required")
-    private String ideBaseClass;
-
-    @Parameter(names = { "-m", "--ideBaseClassTest" }, description = "IDE base test class method to be removed")
-    private String ideBaseClassTest;
-
     public static void main(final String[] args) {
 
         final Application app = new Application();
@@ -60,7 +54,7 @@ public class Application {
             final CommandLineColaProvider provider = new CommandLineColaProvider(app.targetDirectory);
 
             try (final URLClassLoader loader = provider.getTargetClassLoader()) {
-                main = new ColaMain(app.ideBaseClass, app.ideBaseClassTest);
+                main = new ColaMain();
                 main.execute(provider);
             }
 

--- a/cola-tests/src/test/java/cola/ide/BaseColaTest.java
+++ b/cola-tests/src/test/java/cola/ide/BaseColaTest.java
@@ -4,15 +4,13 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
+import com.github.bmsantos.core.cola.story.annotations.IdeEnabler;
+
 public abstract class BaseColaTest {
 
+    @IdeEnabler
     @Test
     public void iWillBeRemoved() {
-        fail("This test should have not been executed");
-    }
-
-    @Test
-    public void toBeRemoved() {
         fail("This test should have not been executed");
     }
 }

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/config/ConfigurationManagerTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/config/ConfigurationManagerTest.java
@@ -9,8 +9,8 @@ import org.junit.Test;
 public class ConfigurationManagerTest {
 
     private static final String ERROR_PROCESSING = "There were errors while processing COLA JUnit Tests.";
-    private static final String WARN_MISSING_IDE_TEST = "ideBaseClassTest method not set. Will look for default JUnit Test named 'iWillBeRemoved' method and remove if available.";
-    private static final String INFO_DEFAULT_CLASS = "Found default ideBaseClass class. Proceeding...";
+    private static final String WARN_TEST = "warning...";
+    private static final String INFO_TEST = "info...";
 
     @Test
     public void shouldLoadProperties() {
@@ -33,18 +33,18 @@ public class ConfigurationManagerTest {
     @Test
     public void shouldGetWarn() {
         // When
-        final String name = config.warn("missing.ide.test");
+        final String name = config.warn("test");
 
         // Then
-        assertThat(name, is(WARN_MISSING_IDE_TEST));
+        assertThat(name, is(WARN_TEST));
     }
 
     @Test
     public void shouldGetInfo() {
         // When
-        final String name = config.info("found.default.ide.class");
+        final String name = config.info("test");
 
         // Then
-        assertThat(name, is(INFO_DEFAULT_CLASS));
+        assertThat(name, is(INFO_TEST));
     }
 }

--- a/cola-tests/src/test/resources/cola-tests-application.properties
+++ b/cola-tests/src/test/resources/cola-tests-application.properties
@@ -1,5 +1,2 @@
 app.name=${project.artifactId}
 app.version=${project.version}
-
-default.ide.class=cola/ide/BaseColaTest
-default.ide.test=iWillBeRemoved

--- a/cola-tests/src/test/resources/cola-tests-messages.properties
+++ b/cola-tests/src/test/resources/cola-tests-messages.properties
@@ -5,9 +5,6 @@ error.failed.processing=Failed to process %s. Error: %s
 error.failed.process.file=Failed to process %s
 error.failed.ide=Failed to process IDE base class
 
-warn.missing.ide.test=ideBaseClassTest method not set. Will look for default JUnit Test named 'iWillBeRemoved' method and remove if available.
+warn.test=warning...
 
-info.missing.ide.class=ideBaseClass not set. Looking for default class.
-info.found.default.ide.class=Found default ideBaseClass class. Proceeding...
-info.missing.default.ide.class=Default class not found. Please set ideBaseClass and ideBaseClassTest properties or create cola/ide/BaseColaTest test class with test method "iWillBeRemoved".
-info.processing=Processing COLA Test: 
+info.test=info...


### PR DESCRIPTION
With the introduction of IdeEnabler annotation, configuration settings for IDE class and method are no longer necessary.

Issue #32