### PR TITLE
Should follow maven filter properties

### DIFF
--- a/cola-tests-compiler/pom.xml
+++ b/cola-tests-compiler/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.bmsantos</groupId>
         <artifactId>cola-tests-base</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
         <relativePath>../cola-tests-base/pom.xml</relativePath>
     </parent>
 

--- a/cola-tests-reports/pom.xml
+++ b/cola-tests-reports/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.bmsantos</groupId>
         <artifactId>cola-tests-base</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
         <relativePath>../cola-tests-base/pom.xml</relativePath>
     </parent>
 

--- a/cola-tests/pom.xml
+++ b/cola-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.bmsantos</groupId>
         <artifactId>cola-tests-base</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1-SNAPSHOT</version>
         <relativePath>../cola-tests-base/pom.xml</relativePath>
     </parent>
 

--- a/cola-tests/src/test/java/cola/ide/AnotherColaTest1.java
+++ b/cola-tests/src/test/java/cola/ide/AnotherColaTest1.java
@@ -1,0 +1,29 @@
+package cola.ide;
+
+import com.github.bmsantos.core.cola.story.annotations.Feature;
+import com.github.bmsantos.core.cola.story.annotations.Given;
+import com.github.bmsantos.core.cola.story.annotations.Then;
+import com.github.bmsantos.core.cola.story.annotations.When;
+
+public class AnotherColaTest1 {
+
+    @Feature
+    private final String feature =
+    "Feature: A feature\n"
+        + "Scenario: A scenario\n"
+        + "Give A\n"
+        + "When B\n"
+        + "Then C";
+
+    @Given("A")
+    public void given() {
+    }
+
+    @When("B")
+    public void when() {
+    }
+
+    @Then("C")
+    public void then() {
+    }
+}

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/instrument/ColaTransformerTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/instrument/ColaTransformerTest.java
@@ -21,7 +21,8 @@ public class ColaTransformerTest {
 
     @Before
     public void setUp() {
-        setProperty("colaTests", ".*Test");
+        setProperty("test", "");
+        setProperty("it.test", "");
         uut = new ColaTransformer();
     }
 
@@ -85,9 +86,9 @@ public class ColaTransformerTest {
     }
 
     @Test
-    public void shouldSetColaTestsFilterPropertyAndSkipNonmatchingClass() throws Exception {
+    public void shouldSetMavenTestFilterPropertyAndSkipNonmatchingClass() throws Exception {
         // Given
-        setProperty("colaTests", ".*Foo");
+        setProperty("test", "*Foo");
         final Class<?> clazz = StoriesFieldTest.class;
         final byte[] original = loadClassBytes(clazz);
 
@@ -97,11 +98,11 @@ public class ColaTransformerTest {
         // Then
         assertThat(result, equalTo(original));
     }
-    
+
     @Test
-    public void shouldSetColaTestsFilterPropertyAndFilterMatchingClass() throws Exception {
+    public void shouldSetMavenTestFilterPropertyAndProcessMatchingClass() throws Exception {
         // Given
-        setProperty("colaTests", ".*FieldTest");
+        setProperty("test", "*FieldTest");
         final Class<?> clazz = StoriesFieldTest.class;
         final byte[] original = loadClassBytes(clazz);
 
@@ -115,12 +116,73 @@ public class ColaTransformerTest {
     @Test
     public void shouldAllowMultipleFilters() throws Exception {
         // Given
-        setProperty("colaTests", ".*FooTest,.*FieldTest");
+        setProperty("test", "*FooTest,*FieldTest");
         final Class<?> clazz = StoriesFieldTest.class;
         final byte[] original = loadClassBytes(clazz);
 
         // When
         final byte[] result = uut.transform(ColaTransformer.class.getClassLoader(), clazz.getName(), clazz, null, original);
+
+        // Then
+        assertThat(result, not(equalTo(original)));
+    }
+
+    @Test
+    public void shouldSetMavenItTestFilterPropertyAndSkipNonmatchingClass() throws Exception {
+        // Given
+        setProperty("it.test", "*Foo");
+        final Class<?> clazz = StoriesFieldTest.class;
+        final byte[] original = loadClassBytes(clazz);
+
+        // When
+        final byte[] result = uut.transform(ColaTransformer.class.getClassLoader(), clazz.getName(), clazz, null,
+            original);
+
+        // Then
+        assertThat(result, equalTo(original));
+    }
+
+    @Test
+    public void shouldSetMavenItTestFilterPropertyAndProcessMatchingClass() throws Exception {
+        // Given
+        setProperty("it.test", "*FieldTest");
+        final Class<?> clazz = StoriesFieldTest.class;
+        final byte[] original = loadClassBytes(clazz);
+
+        // When
+        final byte[] result = uut.transform(ColaTransformer.class.getClassLoader(), clazz.getName(), clazz, null,
+            original);
+
+        // Then
+        assertThat(result, not(equalTo(original)));
+    }
+
+    @Test
+    public void shouldAllowMultipleItTestFilters() throws Exception {
+        // Given
+        setProperty("it.test", "*FooTest,*FieldTest");
+        final Class<?> clazz = StoriesFieldTest.class;
+        final byte[] original = loadClassBytes(clazz);
+
+        // When
+        final byte[] result = uut.transform(ColaTransformer.class.getClassLoader(), clazz.getName(), clazz, null,
+            original);
+
+        // Then
+        assertThat(result, not(equalTo(original)));
+    }
+
+    @Test
+    public void shouldConjugateMultipleItTestFilters() throws Exception {
+        // Given
+        setProperty("test", "*FooTest");
+        setProperty("it.test", "*FieldTest");
+        final Class<?> clazz = StoriesFieldTest.class;
+        final byte[] original = loadClassBytes(clazz);
+
+        // When
+        final byte[] result = uut.transform(ColaTransformer.class.getClassLoader(), clazz.getName(), clazz, null,
+            original);
 
         // Then
         assertThat(result, not(equalTo(original)));

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/main/ColaMainTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/main/ColaMainTest.java
@@ -4,6 +4,7 @@ import static com.github.bmsantos.core.cola.config.ConfigurationManager.config;
 import static com.github.bmsantos.core.cola.utils.ColaUtils.toOSPath;
 import static java.io.File.separator;
 import static java.lang.String.format;
+import static java.lang.System.setProperty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
@@ -45,11 +46,15 @@ public class ColaMainTest {
     private List<String> classes;
 
     private final String testClass = toOSPath("cola/ide/AnotherColaTest.class");
+    private final String testClass1 = toOSPath("cola/ide/AnotherColaTest1.class");
 
     @Before
     public void setUp() {
+        setProperty("test", "");
+
         classes = new ArrayList<>();
         classes.add(testClass);
+        classes.add(testClass1);
 
         provider = new StubProvider();
         provider.setTargetDirectory(TARGET_DIR);
@@ -78,10 +83,12 @@ public class ColaMainTest {
         assertTrue(true);
     }
 
+    // This test requires a clean build
     @Test
     public void shouldProcessTestClasses() throws ColaExecutionException {
         // Given
-        final File testClassFile = new File(TARGET_DIR + separator + testClass);
+        setProperty("test", "*Test1");
+        final File testClassFile = new File(TARGET_DIR + separator + testClass1);
         final long initialSize = testClassFile.length();
 
         // When
@@ -119,7 +126,7 @@ public class ColaMainTest {
 
         // Then
         assertThat(uut.getFailures().size(), is(3));
-        assertThat(logger.getLoggingEvents(), hasItem(error(format(config.error("failed.tests"), 3, 4))));
+        assertThat(logger.getLoggingEvents(), hasItem(error(format(config.error("failed.tests"), 3, 5))));
     }
 
     // This test requires a clean build


### PR DESCRIPTION
Introduced modifications required to have cola tests filtering to follow maven properties.

Examples:
-Dtest=**/*Test
-Dit.test=com/foo/**/*Test

Issue #34