### PR TITLE
Introduce group tagging

### DIFF
--- a/cola-tests-compiler/pom.xml
+++ b/cola-tests-compiler/pom.xml
@@ -19,12 +19,12 @@
         <dependency>
             <groupId>com.github.bmsantos</groupId>
             <artifactId>cola-tests</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.bmsantos</groupId>
             <artifactId>cola-tests-reports</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1-SNAPSHOT</version>
         </dependency>
         <!-- 3rd Party dependencies -->
         <dependency>

--- a/cola-tests-reports/pom.xml
+++ b/cola-tests-reports/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.github.bmsantos</groupId>
             <artifactId>cola-tests</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1-SNAPSHOT</version>
         </dependency>
         <!-- 3rd Party dependencies -->
         <dependency>

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/filters/TagFilter.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/filters/TagFilter.java
@@ -1,25 +1,39 @@
 package com.github.bmsantos.core.cola.filters;
 
-import static com.github.bmsantos.core.cola.utils.ColaUtils.isSet;
+import com.github.bmsantos.core.cola.formatter.FeatureDetails;
+import com.github.bmsantos.core.cola.formatter.ScenarioDetails;
+import com.github.bmsantos.core.cola.formatter.TagStatementDetails;
 import gherkin.formatter.model.Tag;
 
 import java.util.Iterator;
 import java.util.List;
 
-import com.github.bmsantos.core.cola.formatter.FeatureDetails;
-import com.github.bmsantos.core.cola.formatter.ScenarioDetails;
-import com.github.bmsantos.core.cola.formatter.TagStatementDetails;
+import static com.github.bmsantos.core.cola.utils.ColaUtils.isSet;
+import static java.lang.System.getProperties;
+import static java.lang.System.getProperty;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 
 public class TagFilter implements Filter {
 
+    public static final String COLA_TAGS = "cola.group";
     private static final String SKIP = "@skip";
+    private List<String> colaTags = emptyList();
+    private boolean isGroupedExecution = false;
+
+    public TagFilter() {
+        if (getProperties().containsKey(COLA_TAGS)) {
+            colaTags = asList(getProperty(COLA_TAGS).split(","));
+            isGroupedExecution = true;
+        }
+    }
 
     @Override
     public boolean filtrate(final TagStatementDetails statement) {
         if (statement instanceof FeatureDetails) {
             return filterFeature((FeatureDetails) statement);
         }
-        return filterScenario((ScenarioDetails)statement);
+        return filterScenario((ScenarioDetails) statement);
     }
 
     private boolean filterFeature(final FeatureDetails feature) {
@@ -29,7 +43,9 @@ public class TagFilter implements Filter {
 
         final Iterator<ScenarioDetails> it = feature.getScenarios().iterator();
         while (it.hasNext()) {
-            if (filterScenario(it.next())) {
+            final ScenarioDetails next = it.next();
+            if ((isGroupedExecution && !isGrouped(feature.getFeature().getTags()) && filterScenario(next)) ||
+                (!isGroupedExecution && filterScenario(next))) {
                 it.remove();
             }
         }
@@ -38,13 +54,24 @@ public class TagFilter implements Filter {
     }
 
     private boolean filterScenario(final ScenarioDetails scenario) {
-        return skipped(scenario.getScenario().getTags());
+        return skipped(scenario.getScenario().getTags()) || (isGroupedExecution && !isGrouped(scenario.getScenario().getTags()));
     }
 
     private boolean skipped(final List<Tag> tags) {
         if (isSet(tags)) {
             for (final Tag tag : tags) {
                 if (tag.getName().toLowerCase().equals(SKIP)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean isGrouped(final List<Tag> tags) {
+        if (isSet(tags)) {
+            for (final Tag tag : tags) {
+                if (colaTags.contains(tag.getName().substring(1))) {
                     return true;
                 }
             }

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/utils/ColaUtils.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/utils/ColaUtils.java
@@ -21,6 +21,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.File;
 import java.io.UnsupportedEncodingException;
+import java.util.Iterator;
 import java.util.List;
 
 public final class ColaUtils {
@@ -96,4 +97,22 @@ public final class ColaUtils {
         return encode(original, UTF_8.name()).replaceAll("\\+", "%20");
     }
 
+    public static String join(final String separator, final List<String> list) {
+        final Iterator<String> it = list.iterator();
+        String result = "";
+        while (it.hasNext()) {
+            result += it.next() + (it.hasNext() ? separator : "");
+        }
+        return result;
+    }
+
+    public static String joinStrings(final String separator, final String... entries) {
+        String result = "";
+        for (final String entry : entries) {
+            if (entry != null && !entry.isEmpty()) {
+                result += result.isEmpty() ? entry : separator + entry;
+            }
+        }
+        return result;
+    }
 }

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/filters/TagFilterTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/filters/TagFilterTest.java
@@ -1,17 +1,17 @@
 package com.github.bmsantos.core.cola.filters;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
-import java.io.IOException;
-
+import com.github.bmsantos.core.cola.formatter.FeatureDetails;
+import com.github.bmsantos.core.cola.story.annotations.Feature;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import test.utils.TestUtils;
+import java.io.IOException;
 
-import com.github.bmsantos.core.cola.formatter.FeatureDetails;
-import com.github.bmsantos.core.cola.story.annotations.Feature;
+import static java.lang.System.getProperties;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static test.utils.TestUtils.loadFeatures;
 
 public class TagFilterTest {
 
@@ -22,10 +22,15 @@ public class TagFilterTest {
         uut = new TagFilter();
     }
 
+    @After
+    public void tearDown() {
+        getProperties().remove("cola.group");
+    }
+
     @Test
     public void shouldFilterFeaturesWithSkipTag() throws IOException {
         // Given
-        final FeatureDetails feature = TestUtils.loadFeatures("com.github.bmsantos.core.cola.filters.TagFilterTest$SkipFeatureClass").get(0);
+        final FeatureDetails feature = loadFeatures("com.github.bmsantos.core.cola.filters.TagFilterTest$SkipFeatureClass").get(0);
 
         // When
         final boolean result = uut.filtrate(feature);
@@ -37,7 +42,7 @@ public class TagFilterTest {
     @Test
     public void shouldFilterFeaturesWithSkipTagAndSingleScenario() throws IOException {
         // Given
-        final FeatureDetails feature = TestUtils.loadFeatures("com.github.bmsantos.core.cola.filters.TagFilterTest$SkipFeatureWithSingleScenarioClass").get(0);
+        final FeatureDetails feature = loadFeatures("com.github.bmsantos.core.cola.filters.TagFilterTest$SkipFeatureWithSingleScenarioClass").get(0);
 
         // When
         final boolean result = uut.filtrate(feature);
@@ -49,7 +54,35 @@ public class TagFilterTest {
     @Test
     public void shouldKeepFeature() throws IOException {
         // Given
-        final FeatureDetails feature = TestUtils.loadFeatures("com.github.bmsantos.core.cola.filters.TagFilterTest$NormalFeatureClass").get(0);
+        final FeatureDetails feature = loadFeatures("com.github.bmsantos.core.cola.filters.TagFilterTest$NormalFeatureClass").get(0);
+
+        // When
+        final boolean result = uut.filtrate(feature);
+
+        // Then
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void shouldGroupByFeature() throws IOException {
+        // Given
+        getProperties().setProperty("cola.group", "group");
+        uut = new TagFilter();
+        final FeatureDetails feature = loadFeatures("com.github.bmsantos.core.cola.filters.TagFilterTest$GroupFeatureClass").get(0);
+
+        // When
+        final boolean result = uut.filtrate(feature);
+
+        // Then
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void shouldGroupByScenario() throws IOException {
+        // Given
+        getProperties().setProperty("cola.group", "group");
+        uut = new TagFilter();
+        final FeatureDetails feature = loadFeatures("com.github.bmsantos.core.cola.filters.TagFilterTest$GroupScenarioClass").get(0);
 
         // When
         final boolean result = uut.filtrate(feature);
@@ -84,6 +117,28 @@ public class TagFilterTest {
         @Feature
         private final String normalFeature =
         "Feature: Load feature\n"
+            + "Scenario: Should have scenario steps\n"
+            + "Given A\n"
+            + "When B\n"
+            + "Then C\n";
+    }
+
+    private static class GroupFeatureClass {
+        @Feature
+        private final String groupFeature =
+          "@group\n"
+            + "Feature: Load feature\n"
+            + "Scenario: Should have scenario steps\n"
+            + "Given A\n"
+            + "When B\n"
+            + "Then C\n";
+    }
+
+    private static class GroupScenarioClass {
+        @Feature
+        private final String groupScenario =
+          "Feature: Load feature\n"
+            + "@group\n"
             + "Scenario: Should have scenario steps\n"
             + "Given A\n"
             + "When B\n"

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/utils/ColaUtilsTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/utils/ColaUtilsTest.java
@@ -1,15 +1,9 @@
 package com.github.bmsantos.core.cola.utils;
 
-import static com.github.bmsantos.core.cola.utils.ColaUtils.RESOURCE_SEPARATOR;
-import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryFileExists;
-import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryToOS;
-import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryToOsClass;
-import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryToResource;
-import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryToResourceClass;
-import static com.github.bmsantos.core.cola.utils.ColaUtils.classToBinary;
-import static com.github.bmsantos.core.cola.utils.ColaUtils.isSet;
-import static com.github.bmsantos.core.cola.utils.ColaUtils.osToBinary;
+import static com.github.bmsantos.core.cola.utils.ColaUtils.*;
 import static java.io.File.separator;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -19,6 +13,8 @@ import java.util.List;
 import org.junit.Test;
 
 public class ColaUtilsTest {
+
+    public static final String STRING_SEPARATOR = ",";
 
     @Test
     public void shoulBeSet() {
@@ -234,6 +230,40 @@ public class ColaUtilsTest {
 
         // When - Then
         assertThat(binaryFileExists(targetDir, className), is(false));
+    }
+
+    @Test
+    public void shouldJoinStringList() {
+        // Given
+        final List<String> list = asList("ONE", "TWO", "THREE");
+
+        // When
+        final String result = join(STRING_SEPARATOR, list);
+
+        // Then
+        assertThat(result, is("ONE,TWO,THREE"));
+    }
+
+    @Test
+    public void shouldReturnEmptyStringOnEmplyList() {
+        // Given
+        final List<String> list = emptyList();
+
+        // When
+        final String result = join(STRING_SEPARATOR, list);
+
+        // Then
+        assertThat(result.isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldJoinStrings() {
+        // Given
+        // When
+        final String result = joinStrings(STRING_SEPARATOR, "", "ONE", "TWO");
+
+        // Then
+        assertThat(result, is("ONE,TWO"));
     }
 
     private String toOSPath(final String... parts) {


### PR DESCRIPTION
Added group tagging capabilities. Test groups can be added by including one or more named tag into the Feature or Scenario(s).
The execution group can be selected by adding one or more group names to the JVM property "cola.group".

For example:

```gherkin
Feature: Grouped scenarios

  @group1
  Scenario: Should do A
  Given A
  When B
  Then A

  @group2
  Scenario: Should do B
  Given B
  When A
  Then B
```

When executed using -Dcola.group=group1, then the tests will only execute the scenario with the respective tag.
Multiple groups can be selected using csv, e.g. -Dcola.group=group1,group2

Issue #35