### PR TITLE
Introduce group exclusions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os:
   - linux
-  - osx
+#  - osx
 language: java
 jdk:
   - oraclejdk8

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/injector/InjectorClassVisitor.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/injector/InjectorClassVisitor.java
@@ -16,21 +16,16 @@
 package com.github.bmsantos.core.cola.injector;
 
 import static com.github.bmsantos.core.cola.filters.FilterProcessor.filtrate;
+import static java.util.Arrays.asList;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ALOAD;
 import static org.objectweb.asm.Opcodes.ASM4;
 import static org.objectweb.asm.Opcodes.INVOKESTATIC;
 import static org.objectweb.asm.Opcodes.RETURN;
-import gherkin.deps.com.google.gson.Gson;
-import gherkin.formatter.model.Step;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
-
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.MethodVisitor;
 
 import com.github.bmsantos.core.cola.filters.Filter;
 import com.github.bmsantos.core.cola.filters.ReportFilter;
@@ -39,6 +34,10 @@ import com.github.bmsantos.core.cola.formatter.FeatureDetails;
 import com.github.bmsantos.core.cola.formatter.ProjectionValues;
 import com.github.bmsantos.core.cola.formatter.ReportDetails;
 import com.github.bmsantos.core.cola.formatter.ScenarioDetails;
+import gherkin.deps.com.google.gson.Gson;
+import gherkin.formatter.model.Step;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
 
 public class InjectorClassVisitor extends ClassVisitor {
 
@@ -47,7 +46,7 @@ public class InjectorClassVisitor extends ClassVisitor {
     private static final Pattern METHOD_NAME_PATTERN = Pattern.compile(".* : .*");
 
     private final InfoClassVisitor infoClassVisitor;
-    private final List<Filter> filters = Arrays.<Filter> asList(new TagFilter(), new ReportFilter());
+    private final List<Filter> filters = asList(new TagFilter(), new ReportFilter());
 
     public InjectorClassVisitor(final InfoClassVisitor infoClassVisitor) {
         super(ASM4, infoClassVisitor);

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/filters/TagFilterTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/filters/TagFilterTest.java
@@ -25,6 +25,7 @@ public class TagFilterTest {
     @After
     public void tearDown() {
         getProperties().remove("cola.group");
+        getProperties().remove("~cola.group");
     }
 
     @Test
@@ -89,6 +90,34 @@ public class TagFilterTest {
 
         // Then
         assertThat(result, is(false));
+    }
+
+    @Test
+    public void shouldExcludeGroupByFeature() throws IOException {
+        // Given
+        getProperties().setProperty("~cola.group", "group");
+        uut = new TagFilter();
+        final FeatureDetails feature = loadFeatures("com.github.bmsantos.core.cola.filters.TagFilterTest$GroupFeatureClass").get(0);
+
+        // When
+        final boolean result = uut.filtrate(feature);
+
+        // Then
+        assertThat(result, is(true));
+    }
+
+    @Test
+    public void shouldExcludeGroupByScenario() throws IOException {
+        // Given
+        getProperties().setProperty("~cola.group", "group");
+        uut = new TagFilter();
+        final FeatureDetails feature = loadFeatures("com.github.bmsantos.core.cola.filters.TagFilterTest$GroupScenarioClass").get(0);
+
+        // When
+        final boolean result = uut.filtrate(feature);
+
+        // Then
+        assertThat(result, is(true));
     }
 
     private static class SkipFeatureClass {

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/formatter/ProjectionValuesTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/formatter/ProjectionValuesTest.java
@@ -1,26 +1,24 @@
 package com.github.bmsantos.core.cola.formatter;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.List;
+
 import gherkin.formatter.model.Comment;
 import gherkin.formatter.model.Examples;
 import gherkin.formatter.model.ExamplesTableRow;
-
-import java.util.Collections;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
-import com.github.bmsantos.core.cola.formatter.ProjectionValues;
-
 public class ProjectionValuesTest {
 
-    private static final List<Comment> NO_COMMENTS = Collections.<Comment> emptyList();
+    private static final List<Comment> NO_COMMENTS = emptyList();
 
     @Mock
     private Examples examples;

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/injector/InfoClassVisitorTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/injector/InfoClassVisitorTest.java
@@ -119,6 +119,16 @@ public class InfoClassVisitorTest {
         cr.accept(uut, 0);
     }
 
+    @Test(expected = InvalidFeature.class)
+    public void shouldFailToLoadInFeatureWithMalformedProjections() throws IOException {
+        // Given
+        final ClassWriter cw = initClassWriterFor("test.utils.MalformedProjectionTest");
+        uut = new InfoClassVisitor(cw, getClass().getClassLoader());
+
+        // When
+        cr.accept(uut, 0);
+    }
+
     @Test(expected = InvalidFeatureUri.class)
     public void shouldFailToLoadInvalidAnnotatedClass() throws IOException {
         // Given

--- a/cola-tests/src/test/java/test/utils/MalformedProjectionTest.java
+++ b/cola-tests/src/test/java/test/utils/MalformedProjectionTest.java
@@ -1,0 +1,15 @@
+package test.utils;
+
+public class MalformedProjectionTest {
+    private final String stories =
+        "Feature: Malformed examples example\n"
+          + "Scenario Outline: Malformed examples\n"
+          + "Given A\n"
+          + "When B is <foo>\n"
+          + "Then C\n"
+          + "\n"
+          + "Examples:\n"
+          + "| foo\n"
+          + "baa\n"
+          + "boo";
+}


### PR DESCRIPTION
Added modifications that will exclude designated groups from being executed.
Groups ara assigned throgh tags in scenario or features and can be excluded with -D~cola.group=group1,group2 during execution.

Issue #41

Includes fix confirmation for issue #38.