### PR TITLE
Introduce injection mechanism for DependsOn tests

### DIFF
--- a/cola-tests-base/pom.xml
+++ b/cola-tests-base/pom.xml
@@ -56,6 +56,23 @@
                 <version>1.7.7</version>
             </dependency>
             <dependency>
+                <groupId>javax.inject</groupId>
+                <artifactId>javax.inject</artifactId>
+                <version>1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.inject</groupId>
+                <artifactId>guice</artifactId>
+                <version>4.0</version>
+                <classifier>no_aop</classifier>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>aopalliance</artifactId>
+                        <groupId>aopalliance</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-library</artifactId>
                 <version>1.3</version>

--- a/cola-tests/pom.xml
+++ b/cola-tests/pom.xml
@@ -51,7 +51,7 @@
 
         <!-- Test -->
         <dependency>
-        <groupId>org.hamcrest</groupId>
+            <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
         </dependency>
         <dependency>

--- a/cola-tests/pom.xml
+++ b/cola-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.bmsantos</groupId>
         <artifactId>cola-tests-base</artifactId>
-        <version>0.5.0</version>
+        <version>0.5.1-SNAPSHOT</version>
         <relativePath>../cola-tests-base/pom.xml</relativePath>
     </parent>
 
@@ -39,10 +39,19 @@
             <artifactId>junit</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <classifier>no_aop</classifier>
+        </dependency>
 
         <!-- Test -->
         <dependency>
-            <groupId>org.hamcrest</groupId>
+        <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
         </dependency>
         <dependency>
@@ -118,6 +127,9 @@
                         <configuration>
                             <archive>
                                 <manifestEntries>
+                                    <Agent-Class>com.github.bmsantos.core.cola.instrument.ColaInstrument</Agent-Class>
+                                    <Can-Redefine-Classes>true</Can-Redefine-Classes>
+                                    <Can-Retransform-Classes>true</Can-Retransform-Classes>
                                     <Premain-Class>com.github.bmsantos.core.cola.instrument.ColaInstrument</Premain-Class>
                                 </manifestEntries>
                             </archive>

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/injector/ColaInjectableMethodVisitor.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/injector/ColaInjectableMethodVisitor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2001-2005 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.bmsantos.core.cola.injector;
+
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class ColaInjectableMethodVisitor extends MethodVisitor implements Opcodes {
+
+    public static final String PROCESSOR = "com/github/bmsantos/core/cola/story/processor/StoryProcessor";
+    public static final String PROCESSOR_METHOD = "initColaInjector";
+    public static final String PROCESSOR_SIG_TYPE = "(Ljava/lang/Object;)Lcom/google/inject/Injector;";
+
+    private final InfoClassVisitor infoClassVisitor;
+    private boolean initialized = false;
+
+    public ColaInjectableMethodVisitor(final MethodVisitor mv, final InfoClassVisitor infoClassVisitor) {
+        super(ASM4, mv);
+        this.infoClassVisitor = infoClassVisitor;
+    }
+
+    @Override
+    public void visitInsn(final int opcode) {
+        if (!initialized) {
+            if (opcode == RETURN || opcode == DUP) {
+                initialized = true;
+                for (final String field : infoClassVisitor.getColaInjectorFields()) {
+                    mv.visitVarInsn(ALOAD, 0);
+                    mv.visitVarInsn(ALOAD, 0);
+                    mv.visitMethodInsn(INVOKESTATIC, PROCESSOR, PROCESSOR_METHOD, PROCESSOR_SIG_TYPE, false);
+                    mv.visitFieldInsn(PUTFIELD, infoClassVisitor.getClassName(), field, "Lcom/google/inject/Injector;");
+                }
+                if (infoClassVisitor.isColaInjected()) {
+                    mv.visitVarInsn(ALOAD, 0);
+                    mv.visitMethodInsn(INVOKESTATIC, PROCESSOR, PROCESSOR_METHOD, PROCESSOR_SIG_TYPE, false);
+                    mv.visitInsn(POP);
+                }
+            }
+            if (opcode == POP && infoClassVisitor.isColaInjected()) {
+                mv.visitVarInsn(ALOAD, 0);
+                mv.visitMethodInsn(INVOKESTATIC, PROCESSOR, PROCESSOR_METHOD, PROCESSOR_SIG_TYPE, false);
+            }
+        }
+        super.visitInsn(opcode);
+    }
+}

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/injector/InjectorClassVisitor.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/injector/InjectorClassVisitor.java
@@ -15,14 +15,6 @@
  */
 package com.github.bmsantos.core.cola.injector;
 
-import static com.github.bmsantos.core.cola.filters.FilterProcessor.filtrate;
-import static java.util.Arrays.asList;
-import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
-import static org.objectweb.asm.Opcodes.ALOAD;
-import static org.objectweb.asm.Opcodes.ASM4;
-import static org.objectweb.asm.Opcodes.INVOKESTATIC;
-import static org.objectweb.asm.Opcodes.RETURN;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -38,6 +30,14 @@ import gherkin.deps.com.google.gson.Gson;
 import gherkin.formatter.model.Step;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
+
+import static com.github.bmsantos.core.cola.filters.FilterProcessor.filtrate;
+import static java.util.Arrays.asList;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ASM4;
+import static org.objectweb.asm.Opcodes.INVOKESTATIC;
+import static org.objectweb.asm.Opcodes.RETURN;
 
 public class InjectorClassVisitor extends ClassVisitor {
 
@@ -58,7 +58,13 @@ public class InjectorClassVisitor extends ClassVisitor {
         if (METHOD_NAME_PATTERN.matcher(name).matches()) {
             return null;
         }
-        return super.visitMethod(access, name, desc, signature, exceptions);
+
+        final MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+        if (name.equals("<init>") &&
+          (!infoClassVisitor.getColaInjectorFields().isEmpty() || infoClassVisitor.isColaInjected())) {
+            return new ColaInjectableMethodVisitor(mv, infoClassVisitor);
+        }
+        return mv;
     }
 
     @Override

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/instrument/ColaTransformer.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/instrument/ColaTransformer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2001-2005 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.bmsantos.core.cola.instrument;
 
 import static com.github.bmsantos.core.cola.utils.ColaUtils.binaryToOS;

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/annotations/ColaInjectable.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/annotations/ColaInjectable.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2001-2005 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.bmsantos.core.cola.story.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface ColaInjectable {
+    String value() default "";
+}

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/annotations/ColaInjected.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/annotations/ColaInjected.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2001-2005 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.bmsantos.core.cola.story.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface ColaInjected {
+}

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/annotations/ColaInjector.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/annotations/ColaInjector.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2001-2005 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.bmsantos.core.cola.story.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface ColaInjector {
+}

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/processor/BindingsManager.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/processor/BindingsManager.java
@@ -1,0 +1,39 @@
+package com.github.bmsantos.core.cola.story.processor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.lang.Thread.currentThread;
+
+public class BindingsManager {
+
+    private final Map<Long, Map<Class, Map<String, NamedInstance>>> threadBindings = new HashMap<>();
+
+    public  Map<Class, Map<String, NamedInstance>> getBindings() {
+        if (!threadBindings.containsKey(currentThread().getId())) {
+            threadBindings.put(currentThread().getId(), new HashMap<Class, Map<String, NamedInstance>>());
+        }
+        return threadBindings.get(currentThread().getId());
+    }
+
+    public Map<String, NamedInstance> getBindingsForType(final Class type) {
+        final Map<Class, Map<String, NamedInstance>> bindings = getBindings();
+        if (!bindings.containsKey(type)) {
+            bindings.put(type, new HashMap<String, NamedInstance>());
+        }
+        return bindings.get(type);
+    }
+
+    public void addBinding(final Class type, final NamedInstance ni) {
+        Map<String, NamedInstance> bindings = getBindingsForType(type);
+        bindings.put(ni.name, ni);
+    }
+
+    public boolean hasBindings() {
+        return !getBindings().isEmpty();
+    }
+
+    public void reset() {
+        threadBindings.remove(currentThread().getId());
+    }
+}

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/processor/ColaGuiceModule.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/processor/ColaGuiceModule.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2001-2005 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.bmsantos.core.cola.story.processor;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.google.inject.AbstractModule;
+
+import static com.google.inject.name.Names.named;
+
+public class ColaGuiceModule extends AbstractModule {
+
+    private Map<Class, Map<String, NamedInstance>> bindings;
+
+    public ColaGuiceModule(final Map<Class, Map<String, NamedInstance>> bindings) {
+        this.bindings = bindings;
+    }
+
+    @Override
+    protected void configure() {
+        for (final Class clazz : bindings.keySet()) {
+            final Collection<NamedInstance> instances = bindings.get(clazz).values();
+            bind(clazz).toInstance(clazz.cast(instances.iterator().next().instance));
+            for (final NamedInstance namedInstance : instances) {
+                bind(clazz).annotatedWith(named(namedInstance.name)).toInstance(clazz.cast(namedInstance.instance));
+            }
+        }
+    }
+}

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/processor/NamedInstance.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/processor/NamedInstance.java
@@ -13,16 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.bmsantos.core.cola.instrument;
+package com.github.bmsantos.core.cola.story.processor;
 
-import java.lang.instrument.Instrumentation;
-
-public class ColaInstrument {
-    public static void premain(final String agentArgs, final Instrumentation instrumentation) {
-        instrumentation.addTransformer(new ColaTransformer());
-    }
-
-    public static void agentmain(final String agentArgs, final Instrumentation instrumentation) {
-        instrumentation.addTransformer(new ColaTransformer(), true);
-    }
+public class NamedInstance {
+    public String name;
+    public Object instance;
 }

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/injector/InfoClassVisitorTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/injector/InfoClassVisitorTest.java
@@ -1,20 +1,20 @@
 package com.github.bmsantos.core.cola.injector;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
-import static org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
-
 import java.io.IOException;
 
+import com.github.bmsantos.core.cola.exceptions.InvalidFeature;
+import com.github.bmsantos.core.cola.exceptions.InvalidFeatureUri;
 import org.junit.Test;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 
-import com.github.bmsantos.core.cola.exceptions.InvalidFeature;
-import com.github.bmsantos.core.cola.exceptions.InvalidFeatureUri;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
+import static org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
 
 public class InfoClassVisitorTest {
 
@@ -186,6 +186,32 @@ public class InfoClassVisitorTest {
 
         // Then
         assertThat(uut.getIdeEnabledMethods().size(), is(0));
+    }
+
+    @Test
+    public void shouldBeColaInjected() throws IOException {
+        // Given
+        final ClassWriter cw = initClassWriterFor("test.utils.ColaInjectedTest");
+        uut = new InfoClassVisitor(cw, getClass().getClassLoader());
+
+        // When
+        cr.accept(uut, 0);
+
+        // Then
+        assertThat(uut.isColaInjected(), is(true));
+    }
+
+    @Test
+    public void shouldListColaInjectorFields() throws IOException {
+        // Given
+        final ClassWriter cw = initClassWriterFor("test.utils.ColaInjectorTest");
+        uut = new InfoClassVisitor(cw, getClass().getClassLoader());
+
+        // When
+        cr.accept(uut, 0);
+
+        // Then
+        assertThat(uut.getColaInjectorFields(), hasItems("i1", "i2"));
     }
 
     private ClassWriter initClassWriterFor(final String className) throws IOException {

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/story/processor/BindingsManagerTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/story/processor/BindingsManagerTest.java
@@ -1,0 +1,62 @@
+package com.github.bmsantos.core.cola.story.processor;
+
+import java.lang.reflect.Field;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class BindingsManagerTest {
+
+    private final NamedInstance ni = new NamedInstance();
+    private Field field;
+    private BindingsManager uut;
+
+    @Before
+    public void setUp() throws Exception {
+        uut = new BindingsManager();
+
+        field = BindingsManagerTest.class.getDeclaredField("field");
+        ni.name = field.getName();
+        ni.instance = field;
+    }
+
+    @Test
+    public void shouldAddBinding() {
+        // When
+        uut.addBinding(Field.class, ni);
+
+        // Then
+        assertTrue(uut.getBindings().containsKey(Field.class));
+        assertThat(uut.getBindingsForType(Field.class), notNullValue());
+        assertTrue(uut.getBindingsForType(Field.class).containsKey(ni.name));
+    }
+
+    @Test
+    public void shouldHaveBindings() {
+        // Given
+        uut.addBinding(Field.class, ni);
+
+        // When
+        final boolean result = uut.hasBindings();
+
+        // Then
+        assertTrue(result);
+    }
+
+    @Test
+    public void shouldResetBindings() {
+        // Given
+        uut.addBinding(Field.class, ni);
+
+        // When
+        uut.reset();
+
+        // Then
+        assertFalse(uut.hasBindings());
+    }
+}

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/story/processor/StoryProcessorTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/story/processor/StoryProcessorTest.java
@@ -1,15 +1,15 @@
 package com.github.bmsantos.core.cola.story.processor;
 
+import org.junit.Test;
+import test.utils.Story;
+import test.utils.StoryDependsOn;
+import uk.org.lidalia.slf4jtest.TestLogger;
+
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static uk.org.lidalia.slf4jtest.LoggingEvent.warn;
 import static uk.org.lidalia.slf4jtest.TestLoggerFactory.getTestLogger;
-
-import org.junit.Test;
-import test.utils.Story;
-import test.utils.StoryDependsOn;
-import uk.org.lidalia.slf4jtest.TestLogger;
 
 public class StoryProcessorTest {
 

--- a/cola-tests/src/test/java/test/utils/ColaInjectedTest.java
+++ b/cola-tests/src/test/java/test/utils/ColaInjectedTest.java
@@ -1,0 +1,7 @@
+package test.utils;
+
+import com.github.bmsantos.core.cola.story.annotations.ColaInjected;
+
+@ColaInjected
+public class ColaInjectedTest {
+}

--- a/cola-tests/src/test/java/test/utils/ColaInjectorTest.java
+++ b/cola-tests/src/test/java/test/utils/ColaInjectorTest.java
@@ -1,0 +1,13 @@
+package test.utils;
+
+import com.github.bmsantos.core.cola.story.annotations.ColaInjector;
+import com.google.inject.Injector;
+
+public class ColaInjectorTest {
+
+    @ColaInjector
+    public Injector i1;
+
+    @ColaInjector
+    public Injector i2;
+}

--- a/cola-tests/src/test/java/test/utils/StoriesFieldTest.java
+++ b/cola-tests/src/test/java/test/utils/StoriesFieldTest.java
@@ -1,5 +1,8 @@
 package test.utils;
 
+import com.github.bmsantos.core.cola.story.annotations.ColaInjector;
+import com.google.inject.Injector;
+
 public class StoriesFieldTest {
     private final String stories =
         "Feature: Load feature from default field\n"
@@ -7,4 +10,7 @@ public class StoriesFieldTest {
             + "Given A\n"
             + "When B\n"
             + "Then C\n";
+
+    @ColaInjector
+    public Injector colaInjector;
 }

--- a/cola-tests/src/test/java/test/utils/StoryColaInjectable.java
+++ b/cola-tests/src/test/java/test/utils/StoryColaInjectable.java
@@ -13,16 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.bmsantos.core.cola.instrument;
+package test.utils;
 
-import java.lang.instrument.Instrumentation;
+import com.github.bmsantos.core.cola.story.annotations.ColaInjectable;
+import com.github.bmsantos.core.cola.story.annotations.DependsOn;
 
-public class ColaInstrument {
-    public static void premain(final String agentArgs, final Instrumentation instrumentation) {
-        instrumentation.addTransformer(new ColaTransformer());
-    }
+@DependsOn(ColaInjectedTest.class)
+public class StoryColaInjectable extends Story {
 
-    public static void agentmain(final String agentArgs, final Instrumentation instrumentation) {
-        instrumentation.addTransformer(new ColaTransformer(), true);
-    }
+    @ColaInjectable("Zoltan")
+    public Number number1 = new Integer(101);
+
+    @ColaInjectable
+    public Number number2 = new Integer(102);
+
+    @ColaInjectable
+    public String string = "COLA Tests can inject state!";
 }

--- a/cola-tests/src/test/java/test/utils/StoryColaInjected.java
+++ b/cola-tests/src/test/java/test/utils/StoryColaInjected.java
@@ -13,16 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.bmsantos.core.cola.instrument;
+package test.utils;
 
-import java.lang.instrument.Instrumentation;
+import javax.inject.Inject;
+import javax.inject.Named;
 
-public class ColaInstrument {
-    public static void premain(final String agentArgs, final Instrumentation instrumentation) {
-        instrumentation.addTransformer(new ColaTransformer());
-    }
+import com.github.bmsantos.core.cola.story.annotations.ColaInjected;
+import com.github.bmsantos.core.cola.story.annotations.ColaInjector;
+import com.google.inject.Injector;
 
-    public static void agentmain(final String agentArgs, final Instrumentation instrumentation) {
-        instrumentation.addTransformer(new ColaTransformer(), true);
-    }
+@ColaInjected
+public class StoryColaInjected extends Story {
+
+    @Inject
+    @Named("number2")
+    public Number numberB;
+
+    @Inject
+    @Named("Zoltan")
+    public Number numberA;
+
+    @Inject
+    public String string;
+
+    @ColaInjector
+    public Injector colaInjector;
 }


### PR DESCRIPTION
- COLA Tests dependency injection mechanism allow for state to be shared between a COLA Test and another test that it @DependsOn.
- State can be shared by annotating the @ColaInjectable fields on the calling COLA Tests.
- The @ColaInjectable fields will use the field name if no name is provided.
- The @DependsOn test classes have to be annotated with the @ColaInjected annotation.
- The fields to be injected in the @ColaInjected class have to be annotated with @Inject and may be accompanied with @Named annotations.

Issue #48