### PR TITLE
Issue #44 - Should clearly identify failed step

### DIFF
--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/exceptions/ColaStepException.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/exceptions/ColaStepException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2001-2005 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.bmsantos.core.cola.exceptions;
+
+public class ColaStepException extends RuntimeException {
+
+    private static final long serialVersionUID = 7114409537294065656L;
+
+    public ColaStepException() {
+        super();
+    }
+
+    public ColaStepException(final String message) {
+        super(message);
+    }
+
+    public ColaStepException(final Throwable cause) {
+        super(cause);
+    }
+
+    public ColaStepException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/exceptions/ColaStoryException.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/exceptions/ColaStoryException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2001-2005 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.bmsantos.core.cola.exceptions;
+
+public class ColaStoryException extends AssertionError {
+
+    private static final long serialVersionUID = -5959945589265857942L;
+
+    public ColaStoryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/processor/MethodDetails.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/processor/MethodDetails.java
@@ -29,14 +29,21 @@ import com.github.bmsantos.core.cola.story.annotations.Projection;
 
 public class MethodDetails {
 
+    private final String step;
     private final Method method;
     private final List<String> projections;
     private final Object[] arguments;
 
-    private MethodDetails(final Method method, final List<String> projections, final Object[] arguments) {
+    private MethodDetails(final String step, final Method method,
+                          final List<String> projections, final Object[] arguments) {
+        this.step = step;
         this.method = method;
         this.projections = projections;
         this.arguments = arguments;
+    }
+
+    public String getStep() {
+        return step;
     }
 
     public Method getMethod() {
@@ -162,7 +169,7 @@ public class MethodDetails {
         return null;
     }
 
-    public static MethodDetails build(final Method method, final String step,
+    public static MethodDetails build(final String type, final String step, final Method method,
         final Map<String, String> projectionValues, final String annotationValue) {
 
         final List<String> projections = prepareProjections(step);
@@ -172,6 +179,6 @@ public class MethodDetails {
         final Object[] arguments = prepareArguments(method, projections, projectionValues, assignments,
             assignmentValues, groups);
 
-        return new MethodDetails(method, projections, arguments);
+        return new MethodDetails(type + " " + step, method, projections, arguments);
     }
 }

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/story/processor/MethodDetailsTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/story/processor/MethodDetailsTest.java
@@ -20,12 +20,10 @@ import com.github.bmsantos.core.cola.story.annotations.Projection;
 
 public class MethodDetailsTest {
 
-    private static final String STEP = "Given <pints> beers per <alcoholics> developers";
-
+    private static final String TYPE = "Given";
+    private static final String STEP = "<pints> beers per <alcoholics> developers";
     private static final String STEP_GROUPS = "Given 50 beers per 12 developers";
-
     private static final String ANNOTATION_VALUE = "Given (\\d+) beers per (\\d+) developers";
-
     private static final String ASSIGNED_ANNOTATION_VALUE = "Given <pints> beers per <alcoholics> developers";
 
     private MethodDetails uut;
@@ -46,7 +44,7 @@ public class MethodDetailsTest {
     @Test
     public void shouldStoreMethod() {
         // Given
-        uut = MethodDetails.build(method, null, null, null);
+        uut = MethodDetails.build(null, null, method, null, null);
 
         // When
         final Method result = uut.getMethod();
@@ -56,9 +54,21 @@ public class MethodDetailsTest {
     }
 
     @Test
+    public void shouldStoreStepDefinition() {
+        // Given
+        uut = MethodDetails.build(TYPE, STEP, method, null, null);
+
+        // When
+        final String result = uut.getStep();
+
+        // Then
+        assertThat(result, equalTo(TYPE + " " + STEP));
+    }
+
+    @Test
     public void shouldPrepareStepProjections() {
         // Given
-        uut = MethodDetails.build(method, STEP, null, null);
+        uut = MethodDetails.build(null, STEP, method, null, null);
 
         // When
         final List<String> result = uut.getProjections();
@@ -74,7 +84,7 @@ public class MethodDetailsTest {
         projectionValues.put("pints", "100");
         projectionValues.put("alcoholics", "25");
 
-        uut = MethodDetails.build(method, STEP, projectionValues, null);
+        uut = MethodDetails.build(null, STEP, method, projectionValues, null);
 
         // When
         final Object[] result = uut.getArguments();
@@ -86,7 +96,7 @@ public class MethodDetailsTest {
     @Test
     public void shouldPrepareGroupArguments() {
         // Given
-        uut = MethodDetails.build(methodGroups, STEP_GROUPS, null, ANNOTATION_VALUE);
+        uut = MethodDetails.build(null, STEP_GROUPS, methodGroups, null, ANNOTATION_VALUE);
 
         // When
         final Object[] result = uut.getArguments();
@@ -98,7 +108,7 @@ public class MethodDetailsTest {
     @Test
     public void shouldPrepareAssignedArguments() {
         // Given
-        uut = MethodDetails.build(methodAssigned, STEP_GROUPS, null, ASSIGNED_ANNOTATION_VALUE);
+        uut = MethodDetails.build(null, STEP_GROUPS, methodAssigned, null, ASSIGNED_ANNOTATION_VALUE);
 
         // When
         final Object[] result = uut.getArguments();

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/story/processor/StoryProcessorAnnotationTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/story/processor/StoryProcessorAnnotationTest.java
@@ -3,6 +3,7 @@ package com.github.bmsantos.core.cola.story.processor;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.github.bmsantos.core.cola.exceptions.ColaStoryException;
 import com.github.bmsantos.core.cola.formatter.ReportDetails;
 import com.github.bmsantos.core.cola.report.Report;
 import com.github.bmsantos.core.cola.story.annotations.Given;
@@ -189,7 +190,7 @@ public class StoryProcessorAnnotationTest {
         verify(report).report(reportDetails.getArguments(), null);
     }
 
-    @Test(expected = ComparisonFailure.class)
+    @Test(expected = ColaStoryException.class)
     public void shouldUnwrapTheException() throws Throwable {
         // When
         StoryProcessor.process("Feature: I'm a feature", "Scenario: Should Process Story", exceptionStory,


### PR DESCRIPTION
Introduced modifications to clearly identify failing steps.
JUnit final report will now look similar to:

```text
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.397 sec - in com.github.bmsantos.maven.cola.ReportColaTest

Results :

Failed tests:
  FailedExamplesColaTest.An example feature : Should parse examples - projection 0:-1
	Error: Failed to call step: Then I should have <left> cucumbers with projection values: {"start":"12","left":"7h","eat":"5"}
	Cause: For input string: "7h"
  FailedExamplesColaTest.An example feature : Should parse examples - projection 1:-1
	Error: Failed step: Then I should have <left> cucumbers with projection values: {"start":"20","left":"19","eat":"5"}
	Cause:
Expected: <19>
     but: was <15>

Tests run: 35, Failures: 2, Errors: 0, Skipped: 0
```

Issue #44