### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/formatter/FeatureValidator.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/formatter/FeatureValidator.java
@@ -6,6 +6,10 @@ import static com.github.bmsantos.core.cola.utils.ColaUtils.isSet;
 
 public class FeatureValidator {
 
+    private FeatureValidator() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     public static FeatureDetails validate(final FeatureDetails feature, final String fromUri) {
         validateFeature(feature, fromUri);
         return feature;

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/instrument/ColaInstrument.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/instrument/ColaInstrument.java
@@ -18,6 +18,11 @@ package com.github.bmsantos.core.cola.instrument;
 import java.lang.instrument.Instrumentation;
 
 public class ColaInstrument {
+
+    private ColaInstrument() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     public static void premain(final String agentArgs, final Instrumentation instrumentation) {
         instrumentation.addTransformer(new ColaTransformer());
     }

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/processor/StoryProcessor.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/processor/StoryProcessor.java
@@ -59,6 +59,10 @@ public class StoryProcessor {
 
     private static final BindingsManager bindingsManager = new BindingsManager();
 
+    private StoryProcessor() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     public static void ignore(final String feature, final String scenario) {
         log.warn("Feature: " + feature + " - Scenario: " + scenario + " (@ignored)");
     }

--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/utils/ColaUtils.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/utils/ColaUtils.java
@@ -29,6 +29,10 @@ public final class ColaUtils {
     public static final String RESOURCE_SEPARATOR = "/";
     public static final String CLASS_EXT = ".class";
 
+    private ColaUtils() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     public static boolean isSet(final String value) {
         return value != null && !value.isEmpty();
     }

--- a/cola-tests/src/test/java/test/utils/TestUtils.java
+++ b/cola-tests/src/test/java/test/utils/TestUtils.java
@@ -23,6 +23,10 @@ public class TestUtils {
 
     private static final int WRITER_FLAGS = COMPUTE_FRAMES | COMPUTE_MAXS;
 
+    private TestUtils() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     public static List<FeatureDetails> loadFeatures(final String className) throws IOException {
         final ClassReader cr = new ClassReader(className);
         final ClassWriter cw = new ClassWriter(cr, WRITER_FLAGS);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat