### PR TITLE
Should load features from specific classpath

### DIFF
--- a/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/annotations/Features.java
+++ b/cola-tests/src/main/java/com/github/bmsantos/core/cola/story/annotations/Features.java
@@ -24,5 +24,6 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 @Target(TYPE)
 public @interface Features {
-    public String[] value();
+    String classpath() default "";
+    String[] value();
 }

--- a/cola-tests/src/test/java/com/github/bmsantos/core/cola/injector/InfoClassVisitorTest.java
+++ b/cola-tests/src/test/java/com/github/bmsantos/core/cola/injector/InfoClassVisitorTest.java
@@ -74,6 +74,19 @@ public class InfoClassVisitorTest {
     }
 
     @Test
+    public void shouldRetrieveAnnotatedClassFromSpecifiedPath() throws IOException {
+        // Given
+        final ClassWriter cw = initClassWriterFor("test.utils.DirBasedClassAnnotatedTest");
+        uut = new InfoClassVisitor(cw, getClass().getClassLoader());
+
+        // When
+        cr.accept(uut, 0);
+
+        // Then
+        assertThat(uut.getFeatures().isEmpty(), is(false));
+    }
+
+    @Test
     public void shouldRetrieveMultipleAnnotatedClass() throws IOException {
         // Given
         final ClassWriter cw = initClassWriterFor("test.utils.MultipleFilesClassAnnotatedTest");

--- a/cola-tests/src/test/java/test/utils/ClassAnnotatedTest.java
+++ b/cola-tests/src/test/java/test/utils/ClassAnnotatedTest.java
@@ -5,4 +5,3 @@ import com.github.bmsantos.core.cola.story.annotations.Features;
 @Features("gherkin-example")
 public class ClassAnnotatedTest {
 }
-

--- a/cola-tests/src/test/java/test/utils/DirBasedClassAnnotatedTest.java
+++ b/cola-tests/src/test/java/test/utils/DirBasedClassAnnotatedTest.java
@@ -1,0 +1,7 @@
+package test.utils;
+
+import com.github.bmsantos.core.cola.story.annotations.Features;
+
+@Features(classpath = "/path/to/stories", value = "cp-gherkin-example")
+public class DirBasedClassAnnotatedTest {
+}

--- a/cola-tests/src/test/resources/path/to/stories/cp-gherkin-example.feature
+++ b/cola-tests/src/test/resources/path/to/stories/cp-gherkin-example.feature
@@ -1,0 +1,5 @@
+Feature: Load feature annotated class feature
+Scenario: Should have scenario steps
+Given A
+When B
+Then D


### PR DESCRIPTION
Added the option to load features from a specific path from the classpath.

The new lookup rules for @Features are:

1. No classpath attribute is specified - COLA will look for feature files in test package.
2. Classpath is set - COLA will look for feature files in specified classpath path.

Issue #63